### PR TITLE
Remove coverage testing from the scaffold.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,9 +8,6 @@
     "transform-object-assign"
   ],
   "env": {
-    "test": {
-      "plugins": ["istanbul"]
-    },
     "development": {
       "presets": ["react-hmre"]
     }

--- a/circle.yml
+++ b/circle.yml
@@ -4,4 +4,4 @@ machine:
 test:
     override:
         - npm run lint:circleci
-        - npm run test:coverage
+        - npm test

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "ava": "0.15.2",
     "babel-core": "6.11.4",
     "babel-loader": "6.2.4",
-    "babel-plugin-istanbul": "1.0.3",
     "babel-plugin-transform-object-assign": "6.8.0",
     "babel-plugin-transform-object-rest-spread": "6.8.0",
     "babel-preset-es2015": "6.9.0",
@@ -56,7 +55,6 @@
     "minimist": "1.2.0",
     "mobify-code-style": "2.5.1",
     "node-sass": "3.8.0",
-    "nyc": "7.0.0",
     "progressive-web-sdk": "0.0.4",
     "prompt": "1.0.0",
     "raw-loader": "0.5.1",
@@ -79,7 +77,6 @@
     "sasslint": "sass-lint -c node_modules/mobify-code-style/css/.sass-lint.yml 'app/**/*.scss' -v",
     "lint:circleci": "npm run lint && npm run sasslint",
     "test": "ava",
-    "test:coverage": "cross-env NODE_ENV=test nyc ava",
     "test:watch": "npm test -- --watch",
     "styleguide": "styleguidist server"
   },
@@ -89,18 +86,5 @@
     ],
     "babel": "inherit",
     "verbose": true
-  },
-  "nyc": {
-    "reporter": [
-      "text",
-      "html"
-    ],
-    "check-coverage": false,
-    "statements": 100,
-    "branches": 100,
-    "functions": 100,
-    "lines": 100,
-    "sourceMap": false,
-    "instrument": false
   }
 }


### PR DESCRIPTION
Coverage testing breaks tests on some React components. For the moment, then, we need to remove it.

## Changes
- Remove the coverage packages and integration.
- Switch CircleCI testing to just use the plain tests

## How to test-drive this PR
- `npm prune`
- Run `npm test` and `npm run lint` and see that they pass
- See that the build passes on CircleCI with test results.
