### PR TITLE
Add Icons to scaffold

### DIFF
--- a/app/containers/app/container.js
+++ b/app/containers/app/container.js
@@ -2,6 +2,7 @@ import {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import {hidePreloader} from 'progressive-web-sdk/dist/preloader'
 import styles from './app.scss'
+import {Icon, IconSprite} from 'progressive-web-sdk/dist/components/icon'
 
 // import * as appActions from './actions'
 
@@ -16,6 +17,8 @@ class App extends React.Component {
 
         return (
             <div id="outer-container" className="t-app" style={{height: '100%'}}>
+                <IconSprite />
+
                 <main id="page-wrap" className={currentTemplate}>
                     <header>
                         Header content

--- a/app/containers/app/container.js
+++ b/app/containers/app/container.js
@@ -2,7 +2,7 @@ import {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import {hidePreloader} from 'progressive-web-sdk/dist/preloader'
 import styles from './app.scss'
-import {Icon, IconSprite} from 'progressive-web-sdk/dist/components/icon'
+import {IconSprite} from 'progressive-web-sdk/dist/components/icon'
 
 // import * as appActions from './actions'
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "sass-loader": "4.0.0",
     "spline-scss": "2.0.0",
     "tap-mocha-reporter": "0.0.27",
+    "text-loader": "0.0.1",
     "webpack": "1.13.1",
     "webpack-dev-server": "1.14.1"
   },

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -31,6 +31,10 @@ module.exports = {
                 test: /\.scss$/,
                 loader: ExtractTextPlugin.extract(['css', 'sass']),
                 exclude: /node_modules/,
+            },
+            {
+                test: /\.svg$/,
+                loader: 'text'
             }
         )
 


### PR DESCRIPTION
## Changes
- Import and add `IconSprite` into the app container be default

## How to test-drive this PR
- Run `npm install`
- Run `npm run dev`
- [Preview the build](https://preview.mobify.com/?url=http%3A%2F%2Fwww.merlinspotions.com&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- To confirm that the icon sprite is ACTUALLY working, you need to add an icon somewhere. Do this:
    - Open `app/containers/app/container.js`
    - Change `import {IconSprite} from 'progressive-web-sdk/dist/components/icon'` to `import {Icon, IconSprite} from 'progressive-web-sdk/dist/components/icon'`
    - Add `<Icon name="cart-add" />` somewhere in the container
    - Preview the page and confirm that the icon appears as expected.

