### PR TITLE
Bump sdk to 0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "minimist": "1.2.0",
     "mobify-code-style": "2.5.3",
     "node-sass": "3.8.0",
-    "progressive-web-sdk": "0.0.5",
+    "progressive-web-sdk": "0.0.6",
     "prompt": "1.0.0",
     "raw-loader": "0.5.1",
     "react-addons-test-utils": "15.2.1",


### PR DESCRIPTION
## Changes
- Bump SDK to version 0.0.6

## How to test-drive this PR
- `npm run dev`
- Preview merlins potions
- The scaffold should load and run as usual

