### PR TITLE
Bump sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "minimist": "1.2.0",
     "mobify-code-style": "2.5.3",
     "node-sass": "3.8.0",
-    "progressive-web-sdk": "0.0.7",
+    "progressive-web-sdk": "0.0.8",
     "prompt": "1.0.0",
     "raw-loader": "0.5.1",
     "react-addons-test-utils": "15.2.1",


### PR DESCRIPTION
## Changes
- Bump the SDK to version 0.0.8

## How to test-drive this PR
- Ensure the tests pass
- `npm run dev`
- Preview against merlins potions
- The app should run without errors

