### PR TITLE
Rename z-index variables

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -86,7 +86,7 @@ $vertical-input-padding: $unit;
 // ---
 
 // Organizes z-index usage by name. Values can be incremented/decremented
-// slightly as necessary. eg. $stage-layer + 1;
+// slightly as necessary. eg. $z1-layer + 1;
 
 $z1-depth: 1;    // background
 $z2-depth: 10;   // icon or other ui element

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -88,10 +88,10 @@ $vertical-input-padding: $unit;
 // Organizes z-index usage by name. Values can be incremented/decremented
 // slightly as necessary. eg. $stage-layer + 1;
 
-$backdrop-layer: 1;    // background
-$stage-layer: 10;   // icon or other ui element
-$orchestra-layer: 100;  // modal shade or similar
-$frontrow-layer: 1000; // modal dialog or similar
+$z1-depth: 1;    // background
+$z2-depth: 10;   // icon or other ui element
+$z3-depth: 100;  // modal shade or similar
+$z4-depth: 1000; // modal dialog or similar
 
 
 // Shorthand


### PR DESCRIPTION
Due to popular demand, rename the Z-Index variables into something easier to use.

## Changes
- Rename `z-index` away from the theatre stage analogy, and more toward a numbered unit.

## How to test-drive this PR
- Confirm that you feel like this is a good change.

