### PR TITLE
Fall back to desktop if the provided regexes don't match the path.

### DIFF
--- a/app/loader.js
+++ b/app/loader.js
@@ -3,6 +3,10 @@ import {displayPreloader} from 'progressive-web-sdk/dist/preloader'
 
 window.Progressive = {}
 
+// THESE ARE EXAMPLES
+// They work for Merlin's Potions as currently set up.
+// Replace these with what your project needs
+// Later, they will be automatically generated.
 const REACT_REGEXES = [
     /^\/$/,
     /^\/potions\.html$/

--- a/app/loader.js
+++ b/app/loader.js
@@ -3,46 +3,72 @@ import {displayPreloader} from 'progressive-web-sdk/dist/preloader'
 
 window.Progressive = {}
 
+const REACT_REGEXES = [
+    /^\/$/,
+    /^\/potions\.html$/
+]
+
+const isReactRoute = () => {
+    return REACT_REGEXES.some((regex) => regex.test(window.location.pathname))
+}
+
 const CAPTURING_CDN = '//cdn.mobify.com/capturejs/capture-latest.min.js'
 
 import preloadHTML from 'raw!./preloader/preload.html'
 import preloadCSS from 'raw!./preloader/preload.css'
 import preloadJS from 'raw!./preloader/preload.js' // eslint-disable-line import/default
 
-displayPreloader(preloadCSS, preloadHTML, preloadJS)
+if (isReactRoute()) {
+    displayPreloader(preloadCSS, preloadHTML, preloadJS)
 
-// Create React mounting target
-const body = document.getElementsByTagName('body')[0]
-const reactTarget = document.createElement('div')
-reactTarget.className = 'react-target'
-body.appendChild(reactTarget)
+    // Create React mounting target
+    const body = document.getElementsByTagName('body')[0]
+    const reactTarget = document.createElement('div')
+    reactTarget.className = 'react-target'
+    body.appendChild(reactTarget)
 
-/* eslint-disable max-len */
-loadAsset('meta', {
-    name: 'viewport',
-    content: 'width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no'
-})
-/* eslint-enable max-len */
+    /* eslint-disable max-len */
+    loadAsset('meta', {
+        name: 'viewport',
+        content: 'width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no'
+    })
+    /* eslint-enable max-len */
 
-loadAsset('link', {
-    href: getAssetUrl('main.css'),
-    rel: 'stylesheet',
-    type: 'text/css'
-})
+    loadAsset('link', {
+        href: getAssetUrl('main.css'),
+        rel: 'stylesheet',
+        type: 'text/css'
+    })
 
-const script = document.createElement('script')
-script.id = 'progressive-web-script'
-script.src = getAssetUrl('main.js')
-body.appendChild(script)
+    const script = document.createElement('script')
+    script.id = 'progressive-web-script'
+    script.src = getAssetUrl('main.js')
+    body.appendChild(script)
 
-const jQuery = document.createElement('script')
-jQuery.async = true
-jQuery.id = 'progressive-web-jquery'
-jQuery.src = getAssetUrl('static/js/jquery.min.js')
-body.appendChild(jQuery)
+    const jQuery = document.createElement('script')
+    jQuery.async = true
+    jQuery.id = 'progressive-web-jquery'
+    jQuery.src = getAssetUrl('static/js/jquery.min.js')
+    body.appendChild(jQuery)
 
-const capturing = document.createElement('script')
-capturing.async = true
-capturing.id = 'progressive-web-capture'
-capturing.src = CAPTURING_CDN
-body.appendChild(capturing)
+    const capturing = document.createElement('script')
+    capturing.async = true
+    capturing.id = 'progressive-web-capture'
+    capturing.src = CAPTURING_CDN
+    body.appendChild(capturing)
+} else {
+    const capturing = document.createElement('script')
+    capturing.async = true
+    capturing.id = 'progressive-web-capture'
+    capturing.src = CAPTURING_CDN
+    document.body.appendChild(capturing)
+
+    const interval = setInterval(() => {
+        if (window.Capture) {
+            clearInterval(interval)
+            window.Capture.init((capture) => {
+                capture.restore()
+            })
+        }
+    }, 150)
+}


### PR DESCRIPTION
Since automatically extracting the path regexes from the router to the loader is taking a long time, this PR provides a means for controlling the React app loading based on manually-entered regexes. 


## Changes
- Add a basic `isReactRoute` function to the loader
- Fall back to desktop when the function returns false

## How to test-drive this PR
- Preview Merlin's Potions
- Observe that the React app continues to work correctly loading from the home page.
- Observe the desktop site at http://www.merlinspotions.com/books.html
- See that the React site reappears on navigating to the Potions section.
