### PR TITLE
Automatically generate loader route regexes

### DIFF
--- a/app/loader-routes.js
+++ b/app/loader-routes.js
@@ -1,0 +1,3 @@
+// GENERATED FILE DO NOT EDIT
+const routes = [/.*/]
+export default routes

--- a/app/loader.js
+++ b/app/loader.js
@@ -3,17 +3,10 @@ import {displayPreloader} from 'progressive-web-sdk/dist/preloader'
 
 window.Progressive = {}
 
-// THESE ARE EXAMPLES
-// They work for Merlin's Potions as currently set up.
-// Replace these with what your project needs
-// Later, they will be automatically generated.
-const REACT_REGEXES = [
-    /^\/$/,
-    /^\/potions\.html$/
-]
+import ReactRegexes from './loader-routes'
 
 const isReactRoute = () => {
-    return REACT_REGEXES.some((regex) => regex.test(window.location.pathname))
+    return ReactRegexes.some((regex) => regex.test(window.location.pathname))
 }
 
 const CAPTURING_CDN = '//cdn.mobify.com/capturejs/capture-latest.min.js'

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "save-credentials": "sdk-save-credentials",
     "test": "cross-env NODE_ENV=test ava",
     "test:all": "npm run lint && npm test",
-    "test:watch": "npm test -- --watch"
+    "test:watch": "npm test -- --watch",
+    "update-loader-routes": "sdk-get-routes"
   },
   "ava": {
     "files": [


### PR DESCRIPTION
This completes the automation of isReactRoute

 **Linked PRs**: https://github.com/mobify/progressive-web-sdk/pull/100

## Changes
- Modify the loader to import the regexes from `loader-routes.js`. 
- Add a placeholder `loader-routes.js` so that things will always compile
- Add an NPM script for running the route extraction. (This is a slow process that we probably can't do every build)

## How to test-drive this PR
- Install an SDK on the linked branch
- npm run dev and preview
- see that it loads the React app on all routes (/potions.html and /books.html, for example)
- npm run update-loader-routes (this will produce a lot of irrelevant warnings)
- see that it only loads the React app on the correct routes, and not missing routes