### PR TITLE
Add alias for components

### DIFF
--- a/webpack/base.main.js
+++ b/webpack/base.main.js
@@ -18,6 +18,7 @@ module.exports = {
     resolve: {
         alias: {
             react: path.resolve(process.cwd(), 'node_modules', 'react'),
+            components: path.resolve(process.cwd(), 'app', 'components'),
         },
         extensions: ['', '.js', '.jsx']
     },


### PR DESCRIPTION
Adds an alias for local component so importing them is much simpler.

## Changes
- Adds new `components` alias to the project's webpack configuration

## How to test-drive this PR
- In the scaffold run `npm install`
- `npm run add:component` and follow the instructions naming the component `Test`
- Add `import Test from 'components/test'` to app/containers/home/container.js
- Also add `<Test text="hear me roar" />` to the container's render function
- Preview [Merlin's Potions](https://preview.mobify.com/?url=http%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.min.js&disabled=0&domain=&scope=1)
- Notice that the test component should appear on the home page

## Questions
- Should the alias be more specific? Like `progressive-local-components` or something else equally contrived yet less likely to collide with node modules?