### PR TITLE
Add PostCSS (Autoprefixer) and Minification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Add PostCSS (Autoprefixer) and CSS minification
 - Add configuration for building in specific cache manifest files into the main
   and loader build files
+- Move Styleguidist's webpack settings to the `/webpack` directory 
 
 ## 0.0.3 (August 26)
 - use SDK version 0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## To be released
+- Add PostCSS (Autoprefixer) and CSS minification
+
 ## 0.0.3 (August 26)
  - use SDK version 0.1.1
 

--- a/app/loader.js
+++ b/app/loader.js
@@ -12,7 +12,7 @@ const isReactRoute = () => {
 const CAPTURING_CDN = '//cdn.mobify.com/capturejs/capture-latest.min.js'
 
 import preloadHTML from 'raw!./preloader/preload.html'
-import preloadCSS from 'raw!./preloader/preload.css'
+import preloadCSS from 'css?minimize!./preloader/preload.css'
 import preloadJS from 'raw!./preloader/preload.js' // eslint-disable-line import/default
 
 if (isReactRoute()) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "whatwg-fetch": "1.0.0"
   },
   "devDependencies": {
-    "autoprefixer": "^6.4.0",
+    "autoprefixer": "6.4.0",
     "ava": "0.16.0",
     "babel-core": "6.10.4",
     "babel-loader": "6.2.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "lint:sass": "sass-lint -c node_modules/mobify-code-style/css/.sass-lint.yml 'app/**/*.scss' -v",
     "nightwatch": "node ./node_modules/nightwatch/bin/runner.js -c ./tests/system/nightwatch-config.js --retries 1",
     "push": "cross-env NODE_ENV=production npm run build && sdk-upload",
-    "styleguide": "styleguidist server",
+    "styleguide": "styleguidist --config webpack/styleguide.config.js server",
     "save-credentials": "sdk-save-credentials",
     "test": "cross-env NODE_ENV=test ava",
     "test:all": "npm run lint && npm test",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "whatwg-fetch": "1.0.0"
   },
   "devDependencies": {
+    "autoprefixer": "^6.4.0",
     "ava": "0.16.0",
     "babel-core": "6.10.4",
     "babel-loader": "6.2.4",
@@ -58,6 +59,7 @@
     "nightwatch": "0.9.7",
     "nightwatch-commands": "1.7.0",
     "node-sass": "3.8.0",
+    "postcss-loader": "0.11.0",
     "progressive-web-sdk": "0.1.1",
     "prompt": "1.0.0",
     "raw-loader": "0.5.1",

--- a/webpack/base.common.js
+++ b/webpack/base.common.js
@@ -1,0 +1,18 @@
+/* eslint-disable import/no-commonjs */
+/* eslint-env node */
+
+const autoprefixer = require('autoprefixer')
+
+module.exports = {
+    postcss: () => {
+        return [
+            autoprefixer({
+                browsers: [
+                    'iOS >= 6.0',
+                    'Android >= 2.3',
+                    'last 4 ChromeAndroid versions'
+                ]
+            })
+        ]
+    }
+}

--- a/webpack/base.loader.js
+++ b/webpack/base.loader.js
@@ -2,7 +2,7 @@
 /* eslint-env node */
 
 const path = require('path')
-const autoprefixer = require('autoprefixer')
+const baseCommon = require('./base.common')
 
 module.exports = {
     devtool: 'cheap-source-map',
@@ -26,15 +26,5 @@ module.exports = {
             },
         ],
     },
-    postcss: () => {
-        return [
-            autoprefixer({
-                browsers: [
-                    'iOS >= 6.0',
-                    'Android >= 2.3',
-                    'last 4 ChromeAndroid versions'
-                ]
-            })
-        ]
-    }
+    postcss: baseCommon.postcss
 }

--- a/webpack/base.loader.js
+++ b/webpack/base.loader.js
@@ -2,6 +2,7 @@
 /* eslint-env node */
 
 const path = require('path')
+const autoprefixer = require('autoprefixer')
 
 module.exports = {
     devtool: 'cheap-source-map',
@@ -18,6 +19,22 @@ module.exports = {
                 loader: 'babel?presets[]=es2015',
                 cacheDirectory: `${__dirname}/tmp`
             },
+            {
+                test: /\.css?$/,
+                exclude: /node_modules/,
+                loader: 'postcss',
+            },
         ],
+    },
+    postcss: () => {
+        return [
+            autoprefixer({
+                browsers: [
+                    'iOS >= 6.0',
+                    'Android >= 2.3',
+                    'last 4 ChromeAndroid versions'
+                ]
+            })
+        ]
     }
 }

--- a/webpack/base.main.js
+++ b/webpack/base.main.js
@@ -4,7 +4,7 @@
 const path = require('path')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const CopyPlugin = require('copy-webpack-plugin')
-const autoprefixer = require('autoprefixer')
+const baseCommon = require('./base.common')
 
 module.exports = {
     devtool: 'cheap-source-map',
@@ -57,15 +57,5 @@ module.exports = {
             }
         ],
     },
-    postcss: () => {
-        return [
-            autoprefixer({
-                browsers: [
-                    'iOS >= 6.0',
-                    'Android >= 2.3',
-                    'last 4 ChromeAndroid versions'
-                ]
-            })
-        ]
-    }
+    postcss: baseCommon.postcss
 }

--- a/webpack/base.main.js
+++ b/webpack/base.main.js
@@ -54,15 +54,7 @@ module.exports = {
             {
                 test: /\.svg$/,
                 loader: 'text'
-            },
-            {
-                test: /\.scss$/,
-                loader: ExtractTextPlugin.extract(['css?-autoprefixer', 'postcss', 'sass']),
-                include: [
-                    /progressive-web-sdk/,
-                    /app/
-                ]
-            },
+            }
         ],
     },
     postcss: () => {

--- a/webpack/base.main.js
+++ b/webpack/base.main.js
@@ -4,6 +4,7 @@
 const path = require('path')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const CopyPlugin = require('copy-webpack-plugin')
+const autoprefixer = require('autoprefixer')
 
 module.exports = {
     devtool: 'cheap-source-map',
@@ -56,12 +57,23 @@ module.exports = {
             },
             {
                 test: /\.scss$/,
-                loader: ExtractTextPlugin.extract(['css', 'sass']),
+                loader: ExtractTextPlugin.extract(['css?-autoprefixer', 'postcss', 'sass']),
                 include: [
                     /progressive-web-sdk/,
                     /app/
                 ]
             },
         ],
+    },
+    postcss: () => {
+        return [
+            autoprefixer({
+                browsers: [
+                    'iOS >= 6.0',
+                    'Android >= 2.3',
+                    'last 4 ChromeAndroid versions'
+                ]
+            })
+        ]
     }
 }

--- a/webpack/dev.js
+++ b/webpack/dev.js
@@ -25,8 +25,6 @@ mainConfig.module.loaders = mainConfig.module.loaders.concat({
     ]
 })
 
-console.log(mainConfig.module.loaders)
-
 mainConfig.output.publicPath = `https://${ip.address()}:8443/`
 
 mainConfig.plugins = mainConfig.plugins.concat([

--- a/webpack/dev.js
+++ b/webpack/dev.js
@@ -20,7 +20,7 @@ mainConfig.module.loaders = mainConfig.module.loaders.concat({
     test: /\.scss$/,
     loader: ExtractTextPlugin.extract(['css?-autoprefixer', 'postcss', 'sass']),
     include: [
-        /progressive-web-sdk/,
+        /node_modules\/progressive-web-sdk/,
         /app/
     ]
 })

--- a/webpack/dev.js
+++ b/webpack/dev.js
@@ -9,11 +9,23 @@ const dashboard = new Dashboard()
 
 const loaderConfig = require('./base.loader')
 const mainConfig = require('./base.main')
+const ExtractTextPlugin = require('extract-text-webpack-plugin')
 
 mainConfig.entry = mainConfig.entry.concat([
     `webpack-dev-server/client?https://${ip.address()}:8443/`,
     'webpack/hot/only-dev-server'
 ])
+
+mainConfig.module.loaders = mainConfig.module.loaders.concat({
+    test: /\.scss$/,
+    loader: ExtractTextPlugin.extract(['css?-autoprefixer', 'postcss', 'sass']),
+    include: [
+        /progressive-web-sdk/,
+        /app/
+    ]
+})
+
+console.log(mainConfig.module.loaders)
 
 mainConfig.output.publicPath = `https://${ip.address()}:8443/`
 

--- a/webpack/production.js
+++ b/webpack/production.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-commonjs */
 
+const webpack = require('webpack')
 const assign = require('lodash.assign')
 
 const baseLoaderConfig = require('./base.loader')
@@ -9,6 +10,11 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin')
 // Add production flag to main app config
 const productionMainConfig = assign(baseMainConfig, {
     // Extend base config with production settings here
+    plugins: [].concat(baseMainConfig.plugins, [
+        new webpack.DefinePlugin({
+            'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'production')
+        })
+    ])
 })
 
 baseMainConfig.module.loaders = baseMainConfig.module.loaders.concat({

--- a/webpack/production.js
+++ b/webpack/production.js
@@ -4,10 +4,20 @@ const assign = require('lodash.assign')
 
 const baseLoaderConfig = require('./base.loader')
 const baseMainConfig = require('./base.main')
+const ExtractTextPlugin = require('extract-text-webpack-plugin')
 
 // Add production flag to main app config
 const productionMainConfig = assign(baseMainConfig, {
     // Extend base config with production settings here
+})
+
+baseMainConfig.module.loaders = baseMainConfig.module.loaders.concat({
+    test: /\.scss$/,
+    loader: ExtractTextPlugin.extract(['css?-autoprefixer&minification', 'postcss', 'sass']),
+    include: [
+        /progressive-web-sdk/,
+        /app/
+    ]
 })
 
 module.exports = [productionMainConfig, baseLoaderConfig]

--- a/webpack/production.js
+++ b/webpack/production.js
@@ -1,4 +1,5 @@
 /* eslint-disable import/no-commonjs */
+/* eslint-env node */
 
 const webpack = require('webpack')
 const assign = require('lodash.assign')

--- a/webpack/styleguide.config.js
+++ b/webpack/styleguide.config.js
@@ -5,32 +5,30 @@ const path = require('path')
 
 module.exports = {
     title: 'Progressive Web Scaffold',
-    components: './app/components/**/*.jsx',
+    components: '../app/components/**/*.jsx',
     serverHost: '0.0.0.0',
     serverPort: 4000,
     skipComponentsWithoutExample: true,
     updateWebpackConfig(webpackConfig) {
         // Supply our own renderer for styleguide
-        webpackConfig.resolve.alias['rsg-components/Layout/Renderer'] = path.join(__dirname, 'styleguide/renderer')
+        webpackConfig.resolve.alias['rsg-components/Layout/Renderer'] = path.join(__dirname, '../styleguide/renderer')
 
         // Loaders
         webpackConfig.module.loaders.push(
             {
                 test: /\.jsx?$/,
                 exclude: /node_modules/,
-                include: __dirname,
                 loader: 'babel',
                 query: {
                     presets: ['es2015', 'react']
                 },
-                cacheDirectory: `${__dirname}/tmp`
             },
             // Loader for styleguide & project styles
             {
                 test: /\.scss$/,
                 loader: 'style!css!sass',
                 include: [
-                    /progressive-web-sdk/,
+                    /node_modules\/progressive-web-sdk/,
                     /styleguide/
                 ]
             },


### PR DESCRIPTION
Add PostCSS for minification and autoprefixing of our CSS.

## Changes
- Add PostCSS (Autoprefixer) to the loader and preloader
- Minify the CSS on production
- Add some missing settings for production's webpack settings

## How to test-drive this PR
- `main.css`
    - Run `npm i`
    - Run `npm run dev`
    - Preview [Merlin's Potions](https://preview.mobify.com/?url=http%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2F0.0.0.0%3A8443%2Floader.min.js&disabled=0&domain=&scope=1)
    - Confirm that styles are being applied
    - Open [main.scss](https://0.0.0.0:8443/main.css?1472500281307)
    - Confirm that browser prefixes are being added for things like `flexbox`
    - No minification should be happening yet
    - Run `npm run build`
    - Open in your editor: `/build/main.css`
    - Confirm that the CSS is minified
- `preloader.css`
    - In your editor, open up the `/app/loader.js` file
    - inside of the `if (isReactRoute())` block, comment out everything **EXCEPT** the call to `displayPreloader()`
    - run `npm run dev`
    - Preview [Merlin's Potions](https://preview.mobify.com/?url=http%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2F0.0.0.0%3A8443%2Floader.min.js&disabled=0&domain=&scope=1)
    - Inspect the page's `<head>` tag, and open up the `<style>` tag
    - The CSS inside the `<style>` tag should be minified