### PR TITLE
🐛 Fix project styles missing inside styleguide

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "sass-lint": "1.8.2",
     "sass-loader": "4.0.0",
     "spline-scss": "2.2.0",
+    "style-loader": "0.13.1",
     "tap-mocha-reporter": "0.0.27",
     "text-loader": "0.0.1",
     "webpack": "1.13.1",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-commonjs */
 /* eslint-env node */
 
-const ExtractTextPlugin = require('extract-text-webpack-plugin')
+const path = require('path')
 
 module.exports = {
     title: 'Progressive Web SDK',
@@ -10,10 +10,8 @@ module.exports = {
     serverPort: 4000,
     skipComponentsWithoutExample: true,
     updateWebpackConfig(webpackConfig) {
-        // Plugins
-        webpackConfig.plugins.push(
-            new ExtractTextPlugin('css/[name].css')
-        )
+        // Supply our own renderer for styleguide
+        webpackConfig.resolve.alias['rsg-components/Layout/Renderer'] = path.join(__dirname, 'styleguide/renderer')
 
         // Loaders
         webpackConfig.module.loaders.push(
@@ -27,14 +25,22 @@ module.exports = {
                 },
                 cacheDirectory: `${__dirname}/tmp`
             },
+            // Loader for styleguide & project styles
             {
                 test: /\.scss$/,
-                loader: ExtractTextPlugin.extract(['css', 'sass']),
+                loader: 'style!css!sass',
                 include: [
                     /progressive-web-sdk/,
-                    /app/
+                    /styleguide/
                 ]
             },
+            // Loader for plain CSS
+            {
+                test: /\.css$/,
+                loader: 'style!css?modules&importLoaders=1',
+                include: /styleguide/,
+            },
+            // Loader for SVGs
             {
                 test: /\.svg$/,
                 loader: 'text',

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -4,7 +4,7 @@
 const path = require('path')
 
 module.exports = {
-    title: 'Progressive Web SDK',
+    title: 'Progressive Web Scaffold',
     components: './app/components/**/*.jsx',
     serverHost: '0.0.0.0',
     serverPort: 4000,

--- a/styleguide/Layout.css
+++ b/styleguide/Layout.css
@@ -1,0 +1,69 @@
+.root {
+    /*composes: base base-bg from "../../styles/colors.css";*/
+}
+
+.wrapper {
+    padding-left: 200px;
+}
+
+.content {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 15px 30px;
+}
+
+.sidebar {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+
+    overflow: scroll;
+    width: 200px;
+    border-width: 0 1px 0 0;
+
+    background: #f5f5f5;
+
+    /*composes: border from "../../styles/colors.css";*/
+}
+
+.components {
+    overflow: auto; /* to prevent the pane from growing out of the screen */
+}
+
+.heading {
+    display: block;
+    margin: 0;
+    padding: 15px;
+    border-width: 0 0 1px 0;
+
+    font-weight: normal;
+    font-size: 18px;
+
+    /*composes: reset font from "../../styles/common.css";*/
+    /*composes: border from "../../styles/colors.css";*/
+}
+
+.empty {
+    margin: 0 0 30px 0;
+
+    /*composes: font from "../../styles/common.css";*/
+}
+
+.footer {
+    font-size: 12px;
+
+    /*composes: font from "../../styles/common.css";*/
+    /*composes: light from "../../styles/colors.css";*/
+}
+
+.link {
+    /*composes: link from "../../styles/colors.css";*/
+}
+
+.withoutSidebar .wrapper {
+    padding-left: 0;
+}
+.withoutSidebar .sidebar {
+    display: none;
+}

--- a/styleguide/Renderer.jsx
+++ b/styleguide/Renderer.jsx
@@ -2,7 +2,7 @@ import React, {PropTypes} from 'react'
 import classnames from 'classnames'
 import styles from './styleguide.scss'
 
-const s = require('./Layout.css')
+import s from './Layout.css'
 
 const Renderer = ({title, components, toc, sidebar}) => (
     <div className={classnames(s.root, {[s.withoutSidebar]: !sidebar})}>

--- a/styleguide/Renderer.jsx
+++ b/styleguide/Renderer.jsx
@@ -1,0 +1,33 @@
+import React, {PropTypes} from 'react'
+import classnames from 'classnames'
+import styles from './styleguide.scss'
+
+const s = require('./Layout.css')
+
+const Renderer = ({title, components, toc, sidebar}) => (
+    <div className={classnames(s.root, {[s.withoutSidebar]: !sidebar})}>
+        <main className={s.wrapper}>
+            <div className={s.content}>
+                <div className={s.components}>
+                    {components}
+                    <footer className={s.footer}>
+                        Generated with <a className={s.link} href="https://github.com/sapegin/react-styleguidist">React Styleguidist</a>
+                    </footer>
+                </div>
+            </div>
+            <div className={s.sidebar}>
+                <h1 className={s.heading}>{title}</h1>
+                {toc}
+            </div>
+        </main>
+    </div>
+)
+
+Renderer.propTypes = {
+    components: PropTypes.object.isRequired,
+    title: PropTypes.string.isRequired,
+    toc: PropTypes.node.isRequired,
+    sidebar: PropTypes.bool,
+}
+
+export default Renderer

--- a/styleguide/styleguide.scss
+++ b/styleguide/styleguide.scss
@@ -1,0 +1,1 @@
+@import '../app/stylesheet.scss';


### PR DESCRIPTION
Project styles (`app/stylesheet.scss`) weren't being applied to the project styleguide (`npm run styleguide`)

## Changes
- Add a `styleguide/` top-level directory, matching the SDK's implementation for applying styles to the styleguide
- Refactor styleguide's config to properly load all pieces
- Add a `styleguide/styleguide.scss` that simply imports the project stylesheet

## How to test-drive this PR
- Checkout this code
- Create a new component in the project with `npm run add:component`
- Inside the newly generated component, modify its base styles with something easily identifiable (e.g. `background-color: $error-color;` Note the use of a project SCSS var)
- Add your new component's base styles to `app/styles/_components.scss`
- Run `npm run styleguide`
- Visit localhost:4000
- Ensure the newly generated component has the style you created

