### PR TITLE
Move changelog note to correct location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## To be released
 - Add PostCSS (Autoprefixer) and CSS minification
+- Move Styleguidist's webpack settings to the `/webpack` directory
 
 ## 0.0.4 (August 31)
 - Add configuration for building in specific cache manifest files into the main
   and loader build files
-- Move Styleguidist's webpack settings to the `/webpack` directory 
 
 ## 0.0.3 (August 26)
 - use SDK version 0.1.1


### PR DESCRIPTION
Hotfix: A changelog item got added to the wrong spot. Moving it to the correct spot here.

## Changes
- Move changelog item to correct spot ("To Be Release")

