### PR TITLE
Take out webpack dashboard

### DIFF
--- a/webpack/dev.js
+++ b/webpack/dev.js
@@ -3,10 +3,6 @@
 const webpack = require('webpack')
 const ip = require('ip')
 
-const Dashboard = require('webpack-dashboard')
-const DashboardPlugin = require('webpack-dashboard/plugin')
-const dashboard = new Dashboard()
-
 const loaderConfig = require('./base.loader')
 const mainConfig = require('./base.main')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
@@ -30,8 +26,7 @@ mainConfig.output.publicPath = `https://${ip.address()}:8443/`
 mainConfig.plugins = mainConfig.plugins.concat([
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin(),
-    new DashboardPlugin(dashboard.setData)
+    new webpack.NoErrorsPlugin()
 ])
 
 module.exports = [mainConfig, loaderConfig]


### PR DESCRIPTION
## Changes
- Remove webpack dashboard from the webpack dev.js config

## How to test-drive this PR
- checkout this branch
- `npm run dev`
- Ensure the console outputs the original webpack build information, not the webpack dashboard.

