### PR TITLE
Run get-routes on dev

### DIFF
--- a/app/loader-routes.js
+++ b/app/loader-routes.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // GENERATED FILE DO NOT EDIT
-const routes = [/.*/]
+const routes = [/^\/\/?$/,/^\/customer\/account\/login\/?$/,/^\/potions\.html\/?$/]
 export default routes

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "scripts": {
     "add:component": "sdk-generate component",
     "add:page": "sdk-generate page",
-    "build": "sdk-create-hash-manifest && webpack --config webpack/production.js -p --display-error-details --optimize-dedupe",
+    "build": "sdk-get-routes && sdk-create-hash-manifest && webpack --config webpack/production.js -p --display-error-details --optimize-dedupe",
     "dev": "sdk-get-routes && sdk-create-hash-manifest && node ./dev-server/index.js",
     "lint": "npm run lint:js && npm run lint:sass",
     "lint:fix": "npm run lint:js -- --fix",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "add:component": "sdk-generate component",
     "add:page": "sdk-generate page",
     "build": "sdk-create-hash-manifest && webpack --config webpack/production.js -p --display-error-details --optimize-dedupe",
-    "dev": "sdk-create-hash-manifest && node ./dev-server/index.js",
+    "dev": "sdk-get-routes && sdk-create-hash-manifest && node ./dev-server/index.js",
     "lint": "npm run lint:js && npm run lint:sass",
     "lint:fix": "npm run lint:js -- --fix",
     "lint:js": "eslint '**/*.{js,jsx}'",


### PR DESCRIPTION
Previously we had to manually run `sdk-get-routes` to update the loader-routes. This ensures that it runs when the dev server starts so that we don't have to remember.

## Changes
- Runs the sdk-get-routes script when the dev script starts up
- Updates the loader routes

## How to test-drive this PR
- Update one of the routes in the `app/app-provider.jsx` file
- `npm run dev`
- Kill the dev server and ensure that the loader-routes file changed to reflect your updated route.


