### PR TITLE
Add SkipLinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## To be released
 - Add SkipLinks and corresponding nightwatch tests
+- Make Merlin's Potions the initial URL for local Nightwatch tests
 
 ## 0.4.0 (September 20, 2016)
 - Include charset attribute on main script tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## To be released
+- Add SkipLinks and corresponding nightwatch tests
+
 ## 0.4.0 (September 20, 2016)
 - Include charset attribute on main script tag
 - Fix issue with hot-loader errors

--- a/app/components/skip-links/_base.scss
+++ b/app/components/skip-links/_base.scss
@@ -1,0 +1,41 @@
+// SkipLinks
+// ===
+//
+// Skip Links are a simple technique that is used to provide a fast navigation
+// option for non-mouse users. For example, users who interact using keyboards,
+// screen readers or other assistive technologies.
+//
+// SkipLinks remain hidden until they are focused on by, such as by tabbing to
+// it, at which point they become visible.
+//
+// @url: http://webaim.org/techniques/skipnav/
+//
+// 1. Above everything, but underneath modals and their masks
+
+.c-skip-links__anchor {
+    position: absolute;
+    top: $unit;
+    left: -10000px;
+    z-index: $z3-depth - 1; // 1
+
+    display: inline-block;
+    overflow: hidden;
+    width: 1px;
+    height: 1px;
+    padding: $unit/2 $unit;
+    border: 1px solid $neutral-70;
+
+    background-color: #fff;
+
+    color: $neutral-70;
+
+    &:active,
+    &:focus {
+        left: 50%;
+
+        width: auto;
+        height: auto;
+
+        transform: translateX(-50%);
+    }
+}

--- a/app/components/skip-links/index.jsx
+++ b/app/components/skip-links/index.jsx
@@ -1,7 +1,6 @@
 import React, {PropTypes} from 'react'
 
-const SkipLinks = ({fragments}) => {
-
+const SkipLinks = () => {
     return (
         <div className="c-skip-links">
             <a href="#app-main" className="c-skip-links__anchor">
@@ -15,7 +14,6 @@ const SkipLinks = ({fragments}) => {
             <a href="#app-footer" className="c-skip-links__anchor">
                 Skip to footer
             </a>
-
         </div>
     )
 }

--- a/app/components/skip-links/index.jsx
+++ b/app/components/skip-links/index.jsx
@@ -1,8 +1,11 @@
 import React, {PropTypes} from 'react'
+import classNames from 'classnames'
 
-const SkipLinks = () => {
+const SkipLinks = ({className}) => {
+    const classes = classNames('c-skip-links', className)
+
     return (
-        <div className="c-skip-links">
+        <div className={classes}>
             <a href="#app-main" className="c-skip-links__anchor">
                 Skip to content
             </a>
@@ -16,6 +19,13 @@ const SkipLinks = () => {
             </a>
         </div>
     )
+}
+
+SkipLinks.propTypes = {
+    /**
+     * Adds values to the `class` attribute of the root element
+     */
+    className: PropTypes.string
 }
 
 export default SkipLinks

--- a/app/components/skip-links/index.jsx
+++ b/app/components/skip-links/index.jsx
@@ -1,0 +1,23 @@
+import React, {PropTypes} from 'react'
+
+const SkipLinks = ({fragments}) => {
+
+    return (
+        <div className="c-skip-links">
+            <a href="#app-main" className="c-skip-links__anchor">
+                Skip to content
+            </a>
+
+            <a href="#app-navigation" className="c-skip-links__anchor">
+                Skip to main navigation
+            </a>
+
+            <a href="#app-footer" className="c-skip-links__anchor">
+                Skip to footer
+            </a>
+
+        </div>
+    )
+}
+
+export default SkipLinks

--- a/app/components/skip-links/test.js
+++ b/app/components/skip-links/test.js
@@ -1,0 +1,17 @@
+import {mount, shallow} from 'enzyme'
+import React from 'react'
+import 'ignore-styles'
+
+import SkipLinks from './index.jsx'
+
+test('SkipLinks renders without errors', () => {
+    const wrapper = mount(<SkipLinks />)
+    expect(wrapper.length).toBe(1)
+})
+
+/* eslint-disable newline-per-chained-call */
+test('includes the component class name with no className prop', () => {
+    const wrapper = shallow(<SkipLinks />)
+
+    expect(wrapper.first().prop('className').startsWith('c-skip-links')).toBe(true)
+})

--- a/app/containers/app/container.js
+++ b/app/containers/app/container.js
@@ -21,17 +21,17 @@ class App extends React.Component {
                 <SkipLinks />
 
                 <div id="app-wrap" className={currentTemplate}>
-                    <header id="app-header">
+                    <header id="app-header" role="banner">
                         Header content
 
                         <button id="app-navigation">Menu</button>
                     </header>
 
-                    <div id="app-main">
+                    <main id="app-main" role="main">
                         {this.props.children}
-                    </div>
+                    </main>
 
-                    <footer id="app-footer">
+                    <footer id="app-footer" role="contentinfo">
                         Footer content
                     </footer>
                 </div>

--- a/app/containers/app/container.js
+++ b/app/containers/app/container.js
@@ -2,6 +2,7 @@ import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import {hidePreloader} from 'progressive-web-sdk/dist/preloader'
 import {IconSprite} from 'progressive-web-sdk/dist/components/icon'
+import SkipLinks from '../../components/skip-links'
 
 // import * as appActions from './actions'
 
@@ -15,22 +16,25 @@ class App extends React.Component {
         let currentTemplate = `t-${this.props.children.props.route.routeName}`
 
         return (
-            <div id="outer-container" className="t-app">
+            <div id="app" className="t-app">
                 <IconSprite />
+                <SkipLinks />
 
-                <main id="page-wrap" className={currentTemplate}>
-                    <header>
+                <div id="app-wrap" className={currentTemplate}>
+                    <header id="app-header">
                         Header content
+
+                        <button id="app-navigation">Menu</button>
                     </header>
 
-                    <div id="content">
+                    <div id="app-main">
                         {this.props.children}
                     </div>
 
-                    <footer>
+                    <footer id="app-footer">
                         Footer content
                     </footer>
-                </main>
+                </div>
             </div>
         )
     }

--- a/app/containers/home/container.js
+++ b/app/containers/home/container.js
@@ -56,6 +56,10 @@ class Home extends React.Component {
                     This is a test
                 </div>
                 <Button onClick={this.triggerTapEvent}>Themed Component</Button>
+
+                <div id="realContent">
+                    <p>Real Main content!</p>
+                </div>
             </div>
         )
     }

--- a/app/styles/_components.scss
+++ b/app/styles/_components.scss
@@ -3,6 +3,7 @@
 
 // SDK Components' Base Styles
 // ---
+//
 // Uncomment these base styles as the components are used in this project
 
 // @import 'node_modules/progressive-web-sdk/dist/components/accordion/base';
@@ -41,3 +42,4 @@
 @import '../components/button/theme';
 @import '../components/login-form/base';
 @import '../components/skeleton-block/theme';
+@import '../components/skip-links/base';

--- a/tests/system/page-objects/home.js
+++ b/tests/system/page-objects/home.js
@@ -1,5 +1,9 @@
 const selectors = {
-    wrapper: '.t-home'
+    wrapper: '.t-home',
+    skipLinks:    '.c-skip-links',
+    skipToMain:   '.c-skip-links__anchor:first-of-type',
+    skipToNav:    '.c-skip-links__anchor:nth-child(2n)',
+    skipToFooter: '.c-skip-links__anchor:last-of-type',
 }
 
 const Home = function(browser) {

--- a/tests/system/page-objects/home.js
+++ b/tests/system/page-objects/home.js
@@ -1,8 +1,8 @@
 const selectors = {
     wrapper: '.t-home',
-    skipLinks:    '.c-skip-links',
-    skipToMain:   '.c-skip-links__anchor:first-of-type',
-    skipToNav:    '.c-skip-links__anchor:nth-child(2n)',
+    skipLinks: '.c-skip-links',
+    skipToMain: '.c-skip-links__anchor:first-of-type',
+    skipToNav: '.c-skip-links__anchor:nth-child(2n)',
     skipToFooter: '.c-skip-links__anchor:last-of-type',
 }
 

--- a/tests/system/site.js
+++ b/tests/system/site.js
@@ -14,7 +14,7 @@ var Site = {
     profiles: {
         local: {
             bundleUrl: 'https://localhost:8443/loader.min.js',
-            "siteUrl": ""
+            "siteUrl": "http://www.merlinspotions.com"
         },
         production: {
             bundleUrl: '',

--- a/tests/system/site.js
+++ b/tests/system/site.js
@@ -14,7 +14,7 @@ var Site = {
     profiles: {
         local: {
             bundleUrl: 'https://localhost:8443/loader.min.js',
-            "siteUrl": "http://www.merlinspotions.com"
+            "siteUrl": ""
         },
         production: {
             bundleUrl: '',

--- a/tests/system/workflows/home-example.js
+++ b/tests/system/workflows/home-example.js
@@ -2,6 +2,14 @@ import Home from '../page-objects/home'
 
 let home
 
+// On the homepage, at least the following skip
+// links should be present on the page...
+const skipLinkTargets = {
+    main: '#app-main',
+    nav: '#app-navigation',
+    footer: '#app-footer',
+}
+
 export default {
     before: (browser) => {
         home = new Home(browser)
@@ -16,5 +24,19 @@ export default {
             .preview()
             .waitForElementVisible(home.selectors.wrapper)
             .assert.visible(home.selectors.wrapper)
+    },
+
+    'Skip Links': (browser) => {
+        browser
+            // Site should have skip links!
+            .assert.elementPresent(home.selectors.skipLinks)
+
+            // Skip Links and their target should match
+            .assert.elementPresent(skipLinkTargets.main)
+            .assert.elementPresent(skipLinkTargets.nav)
+            .assert.elementPresent(skipLinkTargets.footer)
+            .assert.attributeContains(home.selectors.skipToMain, 'href', skipLinkTargets.main)
+            .assert.attributeContains(home.selectors.skipToNav, 'href', skipLinkTargets.nav)
+            .assert.attributeContains(home.selectors.skipToFooter, 'href', skipLinkTargets.footer)
     }
 }


### PR DESCRIPTION
SkipLinks are an accessibility feature that should be included on all of Mobify's project *by default*. This way, screen reader users, assistive technology and keyboard users are able to skip to relevant content much more easily.

## Changes
- Added SkipLink component to scaffold
- Added nightwatch tests that check to ensure the SkipLinks and their targets are valid (at least on the homepage)
- Make Merlin's Potions the default initial URL for local Nightwatch tests

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlins Potions](https://preview.mobify.com/?url=http%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.min.js&disabled=0&domain=&scope=1)
- (if testing in desktop Chrome) Ensure that dev tools is closed, and then...
    - Click the browser's URL bar
    - On your keyboard, press `tab` until you arrive on the page itself
    - Ensure that you are able to tab to the "Skip to x" links
    - Ensure pressing `enter` on any of the skip links sends you to that link's destination
- (if testing on device) Ensure VoiceOver is activated, and then...
    - Tap Safari's url bar
    - Swipe right ("tabbing") until you arrive on the page itself
    - Ensure that you are able to tab to the "Skip to x" links
    - Ensure double tapping the screen ("clicking") on any of the skip links sends you to that link's destination