### PR TITLE
🎨 Change output loader filename

### DIFF
--- a/tests/jest-setup.js
+++ b/tests/jest-setup.js
@@ -4,4 +4,4 @@ global.Promise = require.requireActual('es6-promise')
 import $ from '../app/static/js/jquery.min.js'
 global.$ = $
 // Prevents a console.error when using asset-utils/getAssetUrl in tests
-global.document.head.innerHTML = '<head><script src="https://localhost:8443/loader.min.js"></script></head>'
+global.document.head.innerHTML = '<head><script src="https://localhost:8443/loader.js"></script></head>'

--- a/tests/system/site.js
+++ b/tests/system/site.js
@@ -13,7 +13,7 @@ var Site = {
     */
     profiles: {
         local: {
-            bundleUrl: 'https://localhost:8443/loader.min.js',
+            bundleUrl: 'https://localhost:8443/loader.js',
             "siteUrl": ""
         },
         production: {

--- a/webpack/base.loader.js
+++ b/webpack/base.loader.js
@@ -9,7 +9,7 @@ module.exports = {
     entry: './app/loader.js',
     output: {
         path: path.resolve(process.cwd(), 'build'),
-        filename: 'loader.min.js'
+        filename: 'loader.js'
     },
     // Loaders are resolved relative to the file being applied to. Specifying the
     // root option here lets Webpack know they are Node modules - avoiding errors


### PR DESCRIPTION
## Changes
- Change the loader's output filename to `loader.js`
- Make sure Jest and Nightwatch tests still work as expected

## How to test-drive this PR
* Clone the [Progressive Web generator](https://github.com/mobify/generator-progressive-web)
* Hop into the generator's generate.sh file and change line 5 to SCAFFOLD_VERSION_OR_BRANCH="change-loader-naming"
* Run the generator in the directory where your test project will be generated: `./path/to/generator/generate.sh`
* Accept the license and provide a test project slug
* Enter "http://www.merlinspotions.com" as the project URL (the URL must include the "http" protocol part for our `.preview()` Nightwatch command)
* Once the new testing project is generated, navigate into the directory
* Due to [this issue](https://github.com/mobify/generator-progressive-web/issues/2), run this command manually:
```egrep -lR "siteUrl" . | tr '\n' '\0' | xargs -0 -n1 sed -i '' "s/\"siteUrl\": \"\"/\"siteUrl\": \"http:\/\/www.merlinspotions.com\"/g" 2>/dev/null```
* Check that Jest tests work: `npm t`
* Check that `loader.js` is the file built: `npm run dev`
* With the dev server running in one terminal instance, start another terminal and navigate to your testing project
* Check that Nightwatch tests work: `npm run nightwatch`
