### PR TITLE
Remove the React Hotloader

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,10 +6,5 @@
   "plugins": [
     "transform-object-rest-spread",
     "transform-object-assign"
-  ],
-  "env": {
-    "development": {
-      "plugins": ["react-hot-loader/babel"]
-    }
-  }
+  ]
 }

--- a/app/main.jsx
+++ b/app/main.jsx
@@ -1,4 +1,4 @@
-import {polyfill} from 'es6-promise'
+import polyfill from 'progressive-web-sdk/dist/polyfill'
 import {initCacheManifest} from 'progressive-web-sdk/dist/asset-utils'
 import cacheHashManifest from '../tmp/cache-hash-manifest.json'
 

--- a/app/main.jsx
+++ b/app/main.jsx
@@ -1,13 +1,10 @@
 import {polyfill} from 'es6-promise'
 import {initCacheManifest} from 'progressive-web-sdk/dist/asset-utils'
 import cacheHashManifest from '../tmp/cache-hash-manifest.json'
-import consoleErrorReporter from 'progressive-web-sdk/dist/console-error-reporter'
 
 // React
 import React from 'react'
 import {render} from 'react-dom'
-
-import {AppContainer} from 'react-hot-loader'
 
 // Redux
 import configureStore from './store'
@@ -31,23 +28,4 @@ const store = configureStore()
 
 const rootEl = document.getElementsByClassName('react-target')[0]
 
-render(
-    <AppContainer errorReporter={consoleErrorReporter}>
-        <AppProvider store={store} />
-    </AppContainer>,
-    rootEl
-)
-
-if (module.hot) {
-    module.hot.accept('./app-provider', () => {
-        // If you use Webpack 2 in ES modules mode, you can
-        // use <App /> here rather than require() a <NextApp />.
-        const NextAppProvider = require('./app-provider').default
-        render(
-            <AppContainer errorReporter={consoleErrorReporter}>
-                <NextAppProvider store={store} />
-            </AppContainer>,
-            rootEl
-        )
-    })
-}
+render(<AppProvider store={store} />, rootEl)

--- a/dev-server/index.js
+++ b/dev-server/index.js
@@ -15,7 +15,6 @@ const compiler = webpack(config)
 
 const server = new WebpackDevServer(compiler, {
     https: true,
-    hot: true,
     stats: {
         // Configures logging: https://webpack.github.io/docs/node.js-api.html#stats
         assets: false,

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "prompt": "1.0.0",
     "raw-loader": "0.5.1",
     "react-addons-test-utils": "15.3.1",
-    "react-hot-loader": "v3.0.0-beta.4",
     "react-styleguidist": "3.0.1",
     "redux-form": "6.0.1",
     "sass-lint": "1.8.2",

--- a/webpack/base.main.js
+++ b/webpack/base.main.js
@@ -10,7 +10,6 @@ const CopyPlugin = require('copy-webpack-plugin')
 module.exports = {
     devtool: 'cheap-source-map',
     entry: [
-        'react-hot-loader/patch',
         'whatwg-fetch',
         './app/main.jsx',
     ],

--- a/webpack/dev.js
+++ b/webpack/dev.js
@@ -7,11 +7,6 @@ const loaderConfig = require('./base.loader')
 const mainConfig = require('./base.main')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 
-mainConfig.entry = mainConfig.entry.concat([
-    `webpack-dev-server/client?https://${ip.address()}:8443/`,
-    'webpack/hot/only-dev-server'
-])
-
 mainConfig.module.loaders = mainConfig.module.loaders.concat({
     test: /\.scss$/,
     loader: ExtractTextPlugin.extract(['css?-autoprefixer&-url', 'postcss', 'sass']),
@@ -25,7 +20,6 @@ mainConfig.output.publicPath = `https://${ip.address()}:8443/`
 
 mainConfig.plugins = mainConfig.plugins.concat([
     new webpack.optimize.OccurenceOrderPlugin(),
-    new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin()
 ])
 


### PR DESCRIPTION
Gets rid of the React hot loader.

 **JIRA**: https://mobify.atlassian.net/browse/WEB-859

## Changes
- Remove all references to the React hot loader

## How to test-drive this PR
- `npm run dev`
- Make sure you can preview Merlin's Potions
- Modify a component's code
- Verify that the browser didn't automatically refresh
- Manually refresh the page and verify the code changes are visible

