### PR TITLE
WEB-888: Internationalization

### DIFF
--- a/app/config/translations.js
+++ b/app/config/translations.js
@@ -1,0 +1,10 @@
+const translations = {
+    'en-US': {
+        'app.goodbye': 'Goodbye {name} :\'('
+    },
+    fr: {
+        'app.goodbye': 'Au Revoir {name} :\'('
+    }
+}
+
+export default translations

--- a/app/config/translations.js
+++ b/app/config/translations.js
@@ -1,5 +1,5 @@
 const translations = {
-    'en-US': {
+    'en-us': {
         'app.goodbye': 'Goodbye {name} :\'(',
         'home.main-content': 'Real Main content!'
     },

--- a/app/config/translations.js
+++ b/app/config/translations.js
@@ -1,9 +1,11 @@
 const translations = {
     'en-US': {
-        'app.goodbye': 'Goodbye {name} :\'('
+        'app.goodbye': 'Goodbye {name} :\'(',
+        'home.main-content': 'Real Main content!'
     },
     fr: {
-        'app.goodbye': 'Au Revoir {name} :\'('
+        'app.goodbye': 'Au Revoir {name} :\'(',
+        'home.main-content': 'Contenu principal réel!'
     }
 }
 

--- a/app/containers/app/actions.js
+++ b/app/containers/app/actions.js
@@ -1,1 +1,3 @@
-// import {createAction} from '../../utils/utils'
+import {createAction} from '../../utils/utils'
+
+export const setLocale = createAction('Changed locale')

--- a/app/containers/app/container.js
+++ b/app/containers/app/container.js
@@ -4,33 +4,13 @@ import {hidePreloader} from 'progressive-web-sdk/dist/preloader'
 import {IconSprite} from 'progressive-web-sdk/dist/components/icon'
 import SkipLinks from '../../components/skip-links'
 
-// import * as appActions from './actions'
+import * as appActions from './actions'
 
 import {addLocaleData, FormattedDate, FormattedMessage, IntlProvider} from 'react-intl'
 import en from 'react-intl/locale-data/en'
 import fr from 'react-intl/locale-data/fr'
 
-const messages = {
-    'en-US': {
-        'app.goodbye': 'Goodbye {name} :\'('
-    },
-    'fr': {
-        'app.goodbye': 'Au Revoir {name} :\'('
-    }
-}
-
 class App extends React.Component {
-
-    constructor() {
-        super()
-
-        this.state = {
-            locale: navigator.language
-        }
-
-        this.changeLocale = this.changeLocale.bind(this)
-    }
-
     componentWillMount() {
         addLocaleData([...en, ...fr])
     }
@@ -40,17 +20,16 @@ class App extends React.Component {
         // Dispatch an action to retrieve global content here
     }
 
-    changeLocale(event) {
-        this.setState({
-            locale: event.target.value
-        })
-    }
-
     render() {
-        let currentTemplate = `t-${this.props.children.props.route.routeName}`
+        const currentTemplate = `t-${this.props.children.props.route.routeName}`
+        const {
+            locale,
+            messages,
+            setLocale
+        } = this.props
 
         return (
-            <IntlProvider locale={this.state.locale} messages={messages[this.state.locale]}>
+            <IntlProvider defaltLocale="en-US" locale={locale} messages={messages}>
                 <div id="app" className="t-app">
                     <IconSprite />
                     <SkipLinks />
@@ -60,10 +39,10 @@ class App extends React.Component {
                             <strong>Date: </strong>
                             <FormattedDate
                                 value={new Date()}
-                                year='numeric'
-                                month='long'
-                                day='numeric'
-                                weekday='long'
+                                year="numeric"
+                                month="long"
+                                day="numeric"
+                                weekday="long"
                             />
 
                             <button id="app-navigation">Menu</button>
@@ -74,8 +53,8 @@ class App extends React.Component {
                             />
 
                             <div>
-                                <label>Language:</label>
-                                <select onChange={this.changeLocale} defaultValue={this.state.locale}>
+                                <label htmlFor="locale-select">Language:</label>
+                                <select id="locale-select" onBlur={setLocale} onChange={setLocale} defaultValue={locale}>
                                     <option value="en-US">English</option>
                                     <option value="fr">French</option>
                                 </select>
@@ -97,17 +76,21 @@ class App extends React.Component {
 }
 
 App.propTypes = {
-    children: PropTypes.element.isRequired
+    children: PropTypes.element.isRequired,
+    locale: PropTypes.string.isRequired,
+    messages: PropTypes.object.isRequired,
+    setLocale: PropTypes.func.isRequired
 }
 
 const mapStateToProps = (state) => {
     return {
-        ...state.app,
+        ...state.app.toJS(),
     }
 }
 
-const mapDispatchToProps = () => {
+const mapDispatchToProps = (dispatch) => {
     return {
+        setLocale: (e) => dispatch(appActions.setLocale(e.target.value))
     }
 }
 

--- a/app/containers/app/container.js
+++ b/app/containers/app/container.js
@@ -29,7 +29,7 @@ class App extends React.Component {
         } = this.props
 
         return (
-            <IntlProvider defaltLocale="en-US" locale={locale} messages={messages}>
+            <IntlProvider defaltLocale="en-US" locale={locale} messages={messages} key={locale}>
                 <div id="app" className="t-app">
                     <IconSprite />
                     <SkipLinks />

--- a/app/containers/app/container.js
+++ b/app/containers/app/container.js
@@ -7,16 +7,31 @@ import {IconSprite} from 'progressive-web-sdk/dist/components/icon'
 
 import {addLocaleData, FormattedDate, FormattedMessage, IntlProvider} from 'react-intl'
 import en from 'react-intl/locale-data/en'
-import ar from 'react-intl/locale-data/ar'
+import fr from 'react-intl/locale-data/fr'
 
-const dict = {
-    'app.goodbye': 'Goodbye {name} :\'('
+const messages = {
+    'en-US': {
+        'app.goodbye': 'Goodbye {name} :\'('
+    },
+    'fr': {
+        'app.goodbye': 'Au Revoir {name} :\'('
+    }
 }
 
 class App extends React.Component {
 
+    constructor() {
+        super()
+
+        this.state = {
+            locale: navigator.language
+        }
+
+        this.changeLocale = this.changeLocale.bind(this)
+    }
+
     componentWillMount() {
-        addLocaleData([...en, ...ar])
+        addLocaleData([...en, ...fr])
     }
 
     componentDidMount() {
@@ -24,17 +39,23 @@ class App extends React.Component {
         // Dispatch an action to retrieve global content here
     }
 
+    changeLocale(event) {
+        this.setState({
+            locale: event.target.value
+        })
+    }
+
     render() {
         let currentTemplate = `t-${this.props.children.props.route.routeName}`
 
         return (
-            <IntlProvider locale="ar" messages={dict}>
+            <IntlProvider locale={this.state.locale} messages={messages[this.state.locale]}>
                 <div id="outer-container" className="t-app">
                     <IconSprite />
 
                     <main id="page-wrap" className={currentTemplate}>
                         <header>
-                            Date:
+                            <strong>Date: </strong>
                             <FormattedDate
                                 value={new Date()}
                                 year='numeric'
@@ -48,6 +69,14 @@ class App extends React.Component {
                             id="app.goodbye"
                             values={{name: 'mike'}}
                             />
+
+                        <div>
+                            <label>Language:</label>
+                            <select onChange={this.changeLocale} defaultValue={this.state.locale}>
+                                <option value="en-US">English</option>
+                                <option value="fr">French</option>
+                            </select>
+                        </div>
 
                         <div id="content">
                             {this.props.children}

--- a/app/containers/app/container.js
+++ b/app/containers/app/container.js
@@ -5,7 +5,20 @@ import {IconSprite} from 'progressive-web-sdk/dist/components/icon'
 
 // import * as appActions from './actions'
 
+import {addLocaleData, FormattedDate, FormattedMessage, IntlProvider} from 'react-intl'
+import en from 'react-intl/locale-data/en'
+import ar from 'react-intl/locale-data/ar'
+
+const dict = {
+    'app.goodbye': 'Goodbye {name} :\'('
+}
+
 class App extends React.Component {
+
+    componentWillMount() {
+        addLocaleData([...en, ...ar])
+    }
+
     componentDidMount() {
         hidePreloader()
         // Dispatch an action to retrieve global content here
@@ -15,23 +28,37 @@ class App extends React.Component {
         let currentTemplate = `t-${this.props.children.props.route.routeName}`
 
         return (
-            <div id="outer-container" className="t-app">
-                <IconSprite />
+            <IntlProvider locale="ar" messages={dict}>
+                <div id="outer-container" className="t-app">
+                    <IconSprite />
 
-                <main id="page-wrap" className={currentTemplate}>
-                    <header>
-                        Header content
-                    </header>
+                    <main id="page-wrap" className={currentTemplate}>
+                        <header>
+                            Date:
+                            <FormattedDate
+                                value={new Date()}
+                                year='numeric'
+                                month='long'
+                                day='numeric'
+                                weekday='long'
+                            />
+                        </header>
 
-                    <div id="content">
-                        {this.props.children}
-                    </div>
+                        <FormattedMessage
+                            id="app.goodbye"
+                            values={{name: 'mike'}}
+                            />
 
-                    <footer>
-                        Footer content
-                    </footer>
-                </main>
-            </div>
+                        <div id="content">
+                            {this.props.children}
+                        </div>
+
+                        <footer>
+                            Footer content
+                        </footer>
+                    </main>
+                </div>
+            </IntlProvider>
         )
     }
 }

--- a/app/containers/app/reducer.js
+++ b/app/containers/app/reducer.js
@@ -4,7 +4,7 @@ import _messages from '../../config/translations'
 import * as appActions from './actions'
 
 const messages = fromJS(_messages)
-const locale = window.navigator.language
+const locale = window.navigator.language.toLowerCase()
 const initialState = Map({
     locale,
     messages: messages.get(locale)

--- a/app/containers/app/reducer.js
+++ b/app/containers/app/reducer.js
@@ -1,11 +1,20 @@
 import {createReducer} from 'redux-act'
-import {Map} from 'immutable'
-// import * as appActions from './actions'
+import {Map, fromJS} from 'immutable'
+import _messages from '../../config/translations'
+import * as appActions from './actions'
 
+const messages = fromJS(_messages)
+const locale = window.navigator.language
 const initialState = Map({
-
+    locale,
+    messages: messages.get(locale)
 })
 
 export default createReducer({
-
+    [appActions.setLocale]: (state, payload) => {
+        return state.merge({
+            locale: payload,
+            messages: messages.get(payload)
+        })
+    }
 }, initialState)

--- a/app/containers/home/container.js
+++ b/app/containers/home/container.js
@@ -1,5 +1,6 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
+import {injectIntl} from 'react-intl'
 
 import Link from 'progressive-web-sdk/dist/components/link'
 import Button from 'progressive-web-sdk/dist/components/button'
@@ -34,6 +35,8 @@ class Home extends React.Component {
     }
 
     render() {
+        const intl = this.props.intl
+
         return (
             <div>
                 <Logo />
@@ -58,7 +61,8 @@ class Home extends React.Component {
                 <Button onClick={this.triggerTapEvent}>Themed Component</Button>
 
                 <div id="realContent">
-                    <p>Real Main content!</p>
+                    {/* An example of injecting strings directly into the app */}
+                    <p>{intl.formatMessage({id: 'home.main-content'})}</p>
                 </div>
             </div>
         )
@@ -67,7 +71,8 @@ class Home extends React.Component {
 
 Home.propTypes = {
     fetchHomeContents: PropTypes.func.isRequired,
-    home: PropTypes.object.isRequired
+    home: PropTypes.object.isRequired,
+    intl: PropTypes.object.isRequired
 }
 
 const mapStateToProps = (state) => {
@@ -85,4 +90,4 @@ const mapDispatchToProps = (dispatch) => {
 export default connect(
     mapStateToProps,
     mapDispatchToProps
-)(Home)
+)(injectIntl(Home))

--- a/app/loader.js
+++ b/app/loader.js
@@ -10,9 +10,15 @@ const isReactRoute = () => {
     return ReactRegexes.some((regex) => regex.test(window.location.pathname))
 }
 
+const getLocales = (locales) => locales.map((loc) => `Intl.~locale.${loc}`).join(',')
+
 initCacheManifest(cacheHashManifest)
 
 const CAPTURING_CDN = '//cdn.mobify.com/capturejs/capture-latest.min.js'
+const SUPPORTED_LOCALES = [
+    'en-US',
+    'fr'
+]
 
 import preloadHTML from 'raw!./preloader/preload.html'
 import preloadCSS from 'css?minimize!./preloader/preload.css'
@@ -39,6 +45,14 @@ if (isReactRoute()) {
         rel: 'stylesheet',
         type: 'text/css'
     })
+
+    // Load the intl polyfill for non-supported browsers for use with react-intl
+    if (!window.Intl) {
+        loadAsset('script', {
+            src: `https://cdn.polyfill.io/v2/polyfill.min.js?features=${getLocales(SUPPORTED_LOCALES)}`,
+            type: 'text/javascript'
+        })
+    }
 
     const script = document.createElement('script')
     script.id = 'progressive-web-script'

--- a/app/loader.js
+++ b/app/loader.js
@@ -16,7 +16,7 @@ initCacheManifest(cacheHashManifest)
 
 const CAPTURING_CDN = '//cdn.mobify.com/capturejs/capture-latest.min.js'
 const SUPPORTED_LOCALES = [
-    'en-US',
+    'en-us',
     'fr'
 ]
 

--- a/package.json
+++ b/package.json
@@ -63,8 +63,10 @@
     "progressive-web-sdk": "0.5.2",
     "prompt": "1.0.0",
     "raw-loader": "0.5.1",
+    "react": "^15.3.2",
     "react-addons-test-utils": "15.3.1",
     "react-hot-loader": "v3.0.0-beta.4",
+    "react-intl": "^2.1.5",
     "react-styleguidist": "3.0.1",
     "redux-form": "6.0.1",
     "sass-lint": "1.8.2",
@@ -96,10 +98,14 @@
   },
   "jest": {
     "cacheDirectory": "./node_modules/cache",
-    "moduleFileExtensions": ["js", "jsx", "json"],
+    "moduleFileExtensions": [
+      "js",
+      "jsx",
+      "json"
+    ],
     "scriptPreprocessor": "tests/jest-preprocessor.js",
     "setupFiles": [
-        "tests/jest-setup.js"
+      "tests/jest-setup.js"
     ],
     "testPathIgnorePatterns": [
       "/webpack/",


### PR DESCRIPTION
Adds `react-intl` and some examples of using it to the scaffold.

 **JIRA**: [WEB-888](https://mobify.atlassian.net/browse/WEB-888)
## Changes
- Adds `react-intl@2.1.5` package
- Adds example of changing locale and translated messages via redux
- Adds example of using `FormattedDate, FormattedMessage` components, as well as injecting `intl` into a component to use API methods like `formatMessage`
## How to test-drive this PR
- `npm install`
- `npm run dev`
- Preview `http://www.merlinspotions.com`
- Note the translated messages on the homepage. Use the select box to change between `en-US` and `fr` and note the changes
