### PR TITLE
Add a utility function for extracting information from Magento JSON

### DIFF
--- a/app/utils/magento-utils.js
+++ b/app/utils/magento-utils.js
@@ -1,0 +1,17 @@
+import Immutable from 'immutable'
+
+/**
+ * Extract all of the JSON pieces in 'text/x-magento-init' script
+ * elements, and merge them together into a single configuration object
+ *
+ * Returns an Immutable Map ready for the Redux store.
+ */
+export const extractMagentoJson = ($html) => {
+    return $html
+        .find('script[x-type="text/x-magento-init"]')
+        .map((_, item) => item.innerHTML)
+        .get()
+        .map(JSON.parse)
+        .map((item) => Immutable.fromJS(item))
+        .reduce((summary, item) => summary.mergeDeep(item), Immutable.Map())
+}

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -41,6 +41,8 @@ export const formEncode = (data) => {
 /**
  * Extract all of the JSON pieces in 'text/x-magento-init' script
  * elements, and merge them together into a single configuration object
+ *
+ * Returns an Immutable Map ready for the Redux store.
  */
 export const extractMagentoJson = ($html) => {
     return $html

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -1,4 +1,5 @@
 import {createAction as actionCreator} from 'redux-act'
+import Immutable from 'immutable'
 
 // simplify redux-act createAction method.
 // usage: createAction('Update Campaign', 'id', 'update')
@@ -35,4 +36,18 @@ export const formEncode = (data) => {
         pairs.push(`${encodeURIComponent(k)}=${encodeURIComponent(data[k])}`)
     })
     return pairs.join('&').replace(/%20/g, '+')
+}
+
+/**
+ * Extract all of the JSON pieces in 'text/x-magento-init' script
+ * elements, and merge them together into a single configuration object
+ */
+export const extractMagentoJson = ($html) => {
+    return $html
+        .find('script[x-type="text/x-magento-init"]')
+        .map((_, item) => item.innerHTML)
+        .get()
+        .map(JSON.parse)
+        .map((item) => Immutable.fromJS(item))
+        .reduce((summary, item) => summary.mergeDeep(item), Immutable.Map())
 }

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -1,5 +1,4 @@
 import {createAction as actionCreator} from 'redux-act'
-import Immutable from 'immutable'
 
 // simplify redux-act createAction method.
 // usage: createAction('Update Campaign', 'id', 'update')
@@ -36,20 +35,4 @@ export const formEncode = (data) => {
         pairs.push(`${encodeURIComponent(k)}=${encodeURIComponent(data[k])}`)
     })
     return pairs.join('&').replace(/%20/g, '+')
-}
-
-/**
- * Extract all of the JSON pieces in 'text/x-magento-init' script
- * elements, and merge them together into a single configuration object
- *
- * Returns an Immutable Map ready for the Redux store.
- */
-export const extractMagentoJson = ($html) => {
-    return $html
-        .find('script[x-type="text/x-magento-init"]')
-        .map((_, item) => item.innerHTML)
-        .get()
-        .map(JSON.parse)
-        .map((item) => Immutable.fromJS(item))
-        .reduce((summary, item) => summary.mergeDeep(item), Immutable.Map())
 }


### PR DESCRIPTION
This PR adds a utility function that extracts all of the information stored in JSON script tags by Magento on a page. It is not (yet) integrated with any parsers

 **JIRA**: N/A

## Changes
- Add the function

## How to test-drive this PR
- import the function into a parser and add `console.log(extractMagentoJson($html).toJS())`
- see that it logs an object with useful information on load.
