### PR TITLE
Add parser utils from the delivery builds with tests

### DIFF
--- a/app/utils/parser-utils.js
+++ b/app/utils/parser-utils.js
@@ -1,0 +1,42 @@
+export const parseLink = ($link) => {
+    return {
+        href: $link.attr('href'),
+        text: $link.text(),
+        title: $link.attr('title')
+    }
+}
+
+export const parseButton = ($button) => {
+    return {
+        text: $button.text(),
+        type: $button.attr('type'),
+        name: $button.attr('name'),
+        value: $button.attr('value'),
+        disabled: !!$button.attr('disabled')
+    }
+}
+
+export const parseImage = ($img) => {
+    return {
+        title: $img.attr('title'),
+        alt: $img.attr('alt'),
+        src: $img.attr('x-src') ? $img.attr('x-src') : $img.attr('src')
+    }
+}
+
+export const parseOption = ($option) => {
+    const value = $option.attr('value')
+    return {
+        key: value,
+        value,
+        selected: !!$option.attr('selected'),
+        text: $option.text()
+    }
+}
+
+export const parseSelect = ($, $select) => {
+    return {
+        name: $select.attr('name'),
+        options: $.makeArray($select.children()).map((item) => parseOption($(item)))
+    }
+}

--- a/app/utils/parser-utils.js
+++ b/app/utils/parser-utils.js
@@ -1,4 +1,4 @@
-export const parseLink = ($link) => {
+export const parseTextLink = ($link) => {
     return {
         href: $link.attr('href'),
         text: $link.text(),

--- a/app/utils/parser-utils.js
+++ b/app/utils/parser-utils.js
@@ -8,7 +8,8 @@ export const parseLink = ($link) => {
 
 export const parseButton = ($button) => {
     return {
-        text: $button.text(),
+        // An interim solution since I don't know what we'll need from here a priori
+        children: $button.html(),
         type: $button.attr('type'),
         name: $button.attr('name'),
         value: $button.attr('value'),

--- a/app/utils/parser-utils.test.js
+++ b/app/utils/parser-utils.test.js
@@ -1,7 +1,7 @@
 import * as ParserUtils from './parser-utils'
 
-test('parseLink returns the correct href, text, and title', () => {
-    expect(ParserUtils.parseLink($('<a href="/test.html" title="Test">Click Here!</a>')))
+test('parseTextLink returns the correct href, text, and title', () => {
+    expect(ParserUtils.parseTextLink($('<a href="/test.html" title="Test">Click Here!</a>')))
         .toEqual({
             href: '/test.html',
             text: 'Click Here!',

--- a/app/utils/parser-utils.test.js
+++ b/app/utils/parser-utils.test.js
@@ -1,0 +1,70 @@
+import * as ParserUtils from './parser-utils'
+
+test('parseLink returns the correct href, text, and title', () => {
+    expect(ParserUtils.parseLink($('<a href="/test.html" title="Test">Click Here!</a>')))
+        .toEqual({
+            href: '/test.html',
+            text: 'Click Here!',
+            title: 'Test'
+        })
+})
+
+test('parseButton returns the correct values', () => {
+    [true, false].forEach((isDisabled) => {
+        const buttonHtml = `<button type="submit" name="Submit" value="test"${isDisabled ? ' disabled' : ''}>Button</button>`
+
+        expect(ParserUtils.parseButton($(buttonHtml)))
+            .toEqual({
+                type: 'submit',
+                text: 'Button',
+                name: 'Submit',
+                value: 'test',
+                disabled: isDisabled
+            })
+    })
+})
+
+test('parseImage returns title, alt, and src', () => {
+    const imageHtml = '<img src="equality.svg" title="Equality Now!" alt="An equals sign" />'
+
+    expect(ParserUtils.parseImage($(imageHtml)))
+        .toEqual({
+            src: 'equality.svg',
+            title: 'Equality Now!',
+            alt: 'An equals sign'
+        })
+
+})
+
+test('parseImage prefers x-src to src', () => {
+    const imageHtml = '<img src="fail.gif" x-src="pass.gif" />'
+
+    expect(ParserUtils.parseImage($(imageHtml)).src).toBe('pass.gif')
+})
+
+test('parseOption gets the right options', () => {
+    [true, false].forEach((isSelected) => {
+        const optionHtml = `<option value="test"${isSelected ? ' selected' : ''}>Option</option>`
+
+        expect(ParserUtils.parseOption($(optionHtml)))
+            .toEqual({
+                key: 'test',
+                value: 'test',
+                selected: isSelected,
+                text: 'Option'
+            })
+    })
+})
+
+test('parseSelect parses the select and its options', () => {
+    const optionVals = ['Jest', 'AVA', 'Mocha']
+    const selectHtml = `<select name="tester">${optionVals.map((val) => `<option value="${val}" />`).join('')}</select>`
+
+    const result = ParserUtils.parseSelect($, $(selectHtml))
+
+    expect(result.name).toBe('tester')
+
+    for (let i = 0; i < optionVals.length; i++) {
+        expect(result.options[i].value).toBe(optionVals[i])
+    }
+})

--- a/app/utils/parser-utils.test.js
+++ b/app/utils/parser-utils.test.js
@@ -16,7 +16,7 @@ test('parseButton returns the correct values', () => {
         expect(ParserUtils.parseButton($(buttonHtml)))
             .toEqual({
                 type: 'submit',
-                text: 'Button',
+                children: 'Button',
                 name: 'Submit',
                 value: 'test',
                 disabled: isDisabled


### PR DESCRIPTION
We should parse elements like links and images in a uniform way, so I looked in the Crabtree and Lancome codebases for the parser utilities they found useful. This imports them to the scaffold and adds tests

## Changes
- Add generic parsers for `a`, `button`, `img`, `option`, and `select` elements
- Add tests

## How to test-drive this PR
- run the tests!
