### PR TITLE
Add more font weights

### DIFF
--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -6,10 +6,8 @@
 //
 // 1. Linter workaround
 
-$base-typography__open-sans: 'https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i|Oswald:300,400,700'; // 1
-$base-typography__oswald: 'https://fonts.googleapis.com/css?family=Oswald'; // 1
-@import url($base-typography__open-sans);
-@import url($base-typography__oswald);
+$base-typography__fonts: 'https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i|Oswald:300,400,700'; // 1
+@import url($base-typography__fonts);
 
 
 // Headers

--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -6,7 +6,7 @@
 //
 // 1. Linter workaround
 
-$base-typography__open-sans: 'https://fonts.googleapis.com/css?family=Open+Sans'; // 1
+$base-typography__open-sans: 'https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i|Oswald:300,400,700'; // 1
 $base-typography__oswald: 'https://fonts.googleapis.com/css?family=Oswald'; // 1
 @import url($base-typography__open-sans);
 @import url($base-typography__oswald);


### PR DESCRIPTION
Add more font weights for Oswald and Open Sans.

## Changes
- Add more weights for Oswald and Open Sans, including specifically:
    - Oswald: 300, 400, and 700
    - Open Sans: 400, 400 italic, 600, 600 italic, 700, and 700 italic

## How to test-drive this PR
- Preview the build (`npm run dev`) or the styleguide (`npm run styleguide`)
- Add the various different font weights to some text and ensure they apply as intended.
