### PR TITLE
Styleguidist Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "prompt": "1.0.0",
     "raw-loader": "0.5.1",
     "react-addons-test-utils": "15.3.2",
-    "react-styleguidist": "3.1.1",
+    "react-styleguidist": "4.1.0",
     "redux-form": "6.0.5",
     "sass-lint": "1.8.2",
     "sass-loader": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "style-loader": "0.13.1",
     "text-loader": "0.0.1",
     "webpack": "1.13.2",
-    "webpack-dev-server": "1.14.1"
+    "webpack-dev-server": "1.14.1",
+    "webpack-hot-middleware": "2.13.0"
   },
   "scripts": {
     "add:component": "sdk-generate component",


### PR DESCRIPTION
Before, running `npm run styleguide` would fail to run. A certain `webpack-hot-middleware` dependency wasn't able to be found if running with npm version 2.x, so this change updates Styleguidist to the latest, and adds the middleware module as a dependency to the scaffold.

## Changes
- Update Styleguidist to 4.1.0
- Add `webpack-hot-middleware` as a dev-dependency

## How to test-drive this PR
- In the repo's root, run `rm -r node_modules/react-styleguidist && rm -r node_modules/webpack-hot-middleware` 
- Run `npm i`
- Run `npm run styleguide` and ensure that the style guide runs and is visitable.
