### PR TITLE
Allow components to restrict when they render

### DIFF
--- a/app/app-provider.jsx
+++ b/app/app-provider.jsx
@@ -29,7 +29,7 @@ const AppProvider = ({store}) => {
 
     const getPageType = (routerState) => getComponentName(routerState.routes[1].component)
 
-    const dispatchRouteChanged = (nextState) => store.dispatch(appActions.onRouteChanged(getPageType(nextState)))
+    const dispatchRouteChanged = (nextState) => store.dispatch(appActions.onRouteChanged(getURL(nextState), getPageType(nextState)))
 
     const dispatchFetchPage = (nextState) => store.dispatch(appActions.fetchPage(getURL(nextState), getPageType(nextState)))
 

--- a/app/containers/app/actions.js
+++ b/app/containers/app/actions.js
@@ -1,33 +1,43 @@
 import {jqueryResponse} from 'progressive-web-sdk/dist/jquery-response'
 import * as utils from '../../utils/utils'
-
+import {CURRENT_URL} from './constants'
 
 /**
  * Action dispatched when the route changes
+ * @param {string} pageType - the component name of the entered route
+ * @param {string} currentURL - what's currently shown in the address bar
  */
-export const onRouteChanged = utils.createAction('On route changed', 'pageType')
+export const onRouteChanged = utils.createAction('On route changed', 'currentURL', 'pageType')
 
 /**
  * Action dispatched when content for a global page render is ready.
+ *
+ * @param {object} $ - a selector library like jQuery
+ * @param {object} $response - a jQuery-wrapped DOM object
+ * @param {string} pageType - the component name of the page received
+ * @param {string} url - the URL of the page received
+ * @param {string} currentURL - what's currently shown in the address bar
  */
 export const onPageReceived = utils.createAction('On page received',
     '$',
     '$response',
-    'pageType'
+    'pageType',
+    'url',
+    'currentURL'
 )
-
 
 /**
  * Fetch the content for a 'global' page render. This should be driven
  * by react-router, ideally.
  */
 export const fetchPage = (url, pageType) => {
-    return (dispatch) => {
+    return (dispatch, getState) => {
         utils.makeRequest(url)
             .then(jqueryResponse)
             .then((res) => {
                 const [$, $response] = res
-                dispatch(onPageReceived($, $response, pageType))
+                const currentURL = getState().app.get(CURRENT_URL)
+                dispatch(onPageReceived($, $response, pageType, url, currentURL))
             })
             .catch((error) => { console.info(error.message) })
     }

--- a/app/containers/app/constants.js
+++ b/app/containers/app/constants.js
@@ -1,0 +1,5 @@
+/**
+ * This file contains constants for use in the application.
+ */
+export const FETCH_IN_PROGRESS = 'fetchInProgress'
+export const CURRENT_URL = 'currentURL'

--- a/app/containers/app/reducer.js
+++ b/app/containers/app/reducer.js
@@ -1,14 +1,18 @@
 import {createReducer} from 'redux-act'
 import {Map} from 'immutable'
 import * as appActions from './actions'
-
-export const FETCH_IN_PROGRESS = 'fetchInProgress'
+import {FETCH_IN_PROGRESS, CURRENT_URL} from './constants'
 
 const initialState = Map({
-    [FETCH_IN_PROGRESS]: false
+    [FETCH_IN_PROGRESS]: false,
+    [CURRENT_URL]: false
 })
 
 export default createReducer({
-    [appActions.onRouteChanged]: (state) => state.set(FETCH_IN_PROGRESS, true),
-    [appActions.onPageReceived]: (state) => state.set(FETCH_IN_PROGRESS, false)
+    [appActions.onRouteChanged]: (state, {currentURL}) => {
+        return state.set(FETCH_IN_PROGRESS, true).set(CURRENT_URL, currentURL)
+    },
+    [appActions.onPageReceived]: (state) => {
+        return state.set(FETCH_IN_PROGRESS, false)
+    }
 }, initialState)

--- a/app/containers/plp/reducer.test.js
+++ b/app/containers/plp/reducer.test.js
@@ -12,7 +12,7 @@ describe('The PLP reducer', () => {
     })
 
     test('stores plp state using the current window.location.href as the key name', () => {
-        const firstHref = 'http://www.foo.com'
+        const firstHref = 'http://www.foo.com/'
         const secondHref = 'http://www.foo.com/home.html'
 
         /**
@@ -26,13 +26,13 @@ describe('The PLP reducer', () => {
             value: firstHref
         })
 
-        const oldState = reducer(initialState, onPageReceived($, $content, 'PLP'))
+        const oldState = reducer(initialState, onPageReceived($, $content, 'PLP', firstHref))
         expect(oldState.has(firstHref)).toBeTruthy()
 
         // Mock changing the URL
         window.location.href = secondHref
 
-        const newState = reducer(initialState, onPageReceived($, $content, 'PLP'))
+        const newState = reducer(initialState, onPageReceived($, $content, 'PLP', secondHref))
         expect(newState.has(secondHref)).toBeTruthy()
     })
 


### PR DESCRIPTION
The PLP has multiple URLs that match it, so if you were to receive multiple `onPageReceived` actions, each one would update the store and render --- but we only want to render the last one. This allows for us to compare the `onPageReceived` request URL to the current URL, and only render if it matches.

 **JIRA**: [WEB-917](https://mobify.atlassian.net/browse/WEB-917)

## Changes
- Provide the request url when dispatching `onPageReceived`
- Provide the current url when dispatching `onRouteChanged`
- Update the `app` store with the current URL, in the `app` reducer for the `onRouteChanged` action
- Add a new condition inside the PLP reducer to only update the store selector when the `onRouteChanged` url matches the current url

## How to test-drive this PR
- `npm run dev`
- Quickly click multiple PLP links by opening the navigation menu and clicking any of the list items, e.g. Potions, Books, Ingredients, etc.
- Verify that this change works properly by seeing that as the responses come in, nothing renders until we receive the response for the last link clicked