### PR TITLE
Set the cache hash manifest baseDir correctly.

### DIFF
--- a/app/config/cache-hash-config.json
+++ b/app/config/cache-hash-config.json
@@ -2,7 +2,7 @@
     "files": [
         "app/static/**/*"
     ],
-    "baseDir": "",
+    "baseDir": "app",
     "hashLength": 8,
     "destinationFolder": "tmp/"
 }


### PR DESCRIPTION
The baseDir for the cache hash manifest should be set to `app`.

## Changes
- Set the `baseDir` to `app`.

## How to test-drive this PR
- Preview Merlin's Potions.
- Open `tmp/cache-hash-manifest.json`.
- Look for `static/img/categories/potions@2x.png` and remember the hash value.
- On the Merlin's homepage, inspect the "Potions" category image.
- Make sure the image contains the hash value you remembered from the cache manifest.

