### PR TITLE
Add: Cart Counter Logic & Badge

### DIFF
--- a/app/components/badge/README.md
+++ b/app/components/badge/README.md
@@ -1,0 +1,12 @@
+```js
+// JS, importing the local component
+import Badge from 'components/badge'
+
+// SCSS, importing the local component styles to app/styles/_components.scss
+@import '../components/badge/base';
+```
+
+
+## Example Usage
+
+    <Badge title="My badge says what">What?</Badge>

--- a/app/components/badge/_base.scss
+++ b/app/components/badge/_base.scss
@@ -1,0 +1,15 @@
+// Badge
+// ===
+
+.c-badge {
+    display: inline-block;
+    min-width: $unit*2.5;
+    min-height: $unit*2.5;
+    padding: $unit/2;
+
+    border-radius: $unit*1.5;
+    background: $accent-color;
+
+    font-size: $font-size - 2;
+    line-height: $font-size - 2;
+}

--- a/app/components/badge/index.jsx
+++ b/app/components/badge/index.jsx
@@ -1,0 +1,49 @@
+import React, {PropTypes} from 'react'
+import classNames from 'classnames'
+
+const componentClass = 'c-badge'
+
+/**
+ * A badge is a simple, circular element used to display small amounts of
+ * important information, such as the number of items in a cart.
+ */
+
+const Badge = ({
+    className,
+    title,
+    children,
+}) => {
+    const classes = classNames(componentClass, className)
+
+    return (
+        <span className={classes}>
+            <span aria-hidden="true">{children}</span>
+
+            {title &&
+                <span className="u-visually-hidden">{title}</span>
+            }
+        </span>
+    )
+}
+
+
+Badge.propTypes = {
+    /**
+     * The title provides text for user agents like screen readers
+     */
+    title: PropTypes.string.isRequired,
+
+    /**
+     * Any children to be nested within this ProductItem. **Note!** This is
+     * intentionally hidden from screen readers! Use the `title` to provide
+     * meaningful text instead.
+     */
+    children: PropTypes.node,
+
+    /**
+     * Adds values to the `class` attribute of the root element
+     */
+    className: PropTypes.string,
+}
+
+export default Badge

--- a/app/components/badge/index.jsx
+++ b/app/components/badge/index.jsx
@@ -34,7 +34,7 @@ Badge.propTypes = {
     title: PropTypes.string.isRequired,
 
     /**
-     * Any children to be nested within this ProductItem. **Note!** This is
+     * Any children to be nested within this Badge. **Note!** This is
      * intentionally hidden from screen readers! Use the `title` to provide
      * meaningful text instead.
      */

--- a/app/components/badge/test.js
+++ b/app/components/badge/test.js
@@ -1,0 +1,57 @@
+import {mount, shallow} from 'enzyme'
+import React from 'react'
+
+import Badge from './index.jsx'
+
+test('Badge renders without errors', () => {
+    const wrapper = mount(<Badge title="test" />)
+    expect(wrapper.length).toBe(1)
+})
+
+/* eslint-disable newline-per-chained-call */
+test('includes the component class name with no className prop', () => {
+    const wrapper = shallow(<Badge title="test" />)
+
+    expect(wrapper.hasClass('c-badge')).toBe(true)
+})
+
+test('does not render an \'undefined\' class with no className', () => {
+    const wrapper = shallow(<Badge title="test" />)
+
+    expect(wrapper.hasClass('undefined')).toBe(false)
+})
+
+test('renders the contents of the className prop if present', () => {
+    [
+        'test',
+        'test another'
+    ].forEach((name) => {
+        const wrapper = shallow(<Badge className={name} title="test" />)
+
+        expect(wrapper.hasClass(name)).toBe(true)
+    })
+})
+
+test('renders the contents of the title prop if present', () => {
+    [
+        'test',
+        'test another'
+    ].forEach((title) => {
+        const wrapper = shallow(<Badge title={title} />)
+
+        expect(wrapper.find('.u-visually-hidden').length).toBe(1)
+    })
+})
+
+test('renders the contents of the children prop if present', () => {
+    [
+        'test',
+        'test another'
+    ].forEach((text) => {
+        const content = <span className="x-test">{text}</span>
+        const wrapper = shallow(<Badge title="">{content}</Badge>)
+
+        expect(wrapper.find('.x-test').length).toBe(1)
+        expect(wrapper.find('.x-test').text()).toBe(text)
+    })
+})

--- a/app/components/badge/test.js
+++ b/app/components/badge/test.js
@@ -40,6 +40,7 @@ test('renders the contents of the title prop if present', () => {
         const wrapper = shallow(<Badge title={title} />)
 
         expect(wrapper.find('.u-visually-hidden').length).toBe(1)
+        expect(wrapper.find('.u-visually-hidden').text()).toBe(title)
     })
 })
 

--- a/app/components/button/_theme.scss
+++ b/app/components/button/_theme.scss
@@ -14,6 +14,11 @@
 
     -webkit-appearance: none;
 
+    &:active,
+    &:focus {
+        background: rgba(255, 255, 255, 0.1);
+    }
+
     &.c--is-anchor {
         display: inline-flex;
     }

--- a/app/containers/header/_header.scss
+++ b/app/containers/header/_header.scss
@@ -100,3 +100,15 @@
     width: 67px;
     height: 28px;
 }
+
+
+// Badge
+// ---
+//
+// 1. Absolutely positioned relative to the parent `.u-position-relative` container
+
+.t-header__badge {
+    position: absolute; // 1
+    top: 0;
+    right: 0;
+}

--- a/app/containers/header/container.js
+++ b/app/containers/header/container.js
@@ -11,6 +11,11 @@ import Link from 'progressive-web-sdk/dist/components/link'
 import logo from '../../static/svg/logo.svg'
 import DangerousHTML from 'progressive-web-sdk/dist/components/dangerous-html'
 
+const generateCartCounterText = (cartContents) => {
+    return cartContents && cartContents.summary_count && cartContents.summary_count > 0 ?
+        `Cart - ${cartContents.summary_count}` :
+        'Cart'
+}
 
 class Header extends React.Component {
     constructor(props) {
@@ -39,7 +44,8 @@ class Header extends React.Component {
 
     render() {
         const {onMenuClick, onMiniCartClick} = this.props
-        const {isCollapsed} = this.props.header.toJS()
+        const {isCollapsed, cart} = this.props.header.toJS()
+        const cartCounterText = generateCartCounterText(cart)
 
         const innerButtonClassName = classnames('t-header__inner-button', 'u-padding-0', {
             't--hide-label': isCollapsed
@@ -81,7 +87,7 @@ class Header extends React.Component {
 
                     <HeaderBarActions>
                         <Button innerClassName={innerButtonClassName} onClick={onMiniCartClick}>
-                            <IconLabel label="Cart" iconName="cart" iconSize="medium" />
+                            <IconLabel label={cartCounterText} iconName="cart" iconSize="medium" />
                         </Button>
                     </HeaderBarActions>
                 </HeaderBar>

--- a/app/containers/header/container.js
+++ b/app/containers/header/container.js
@@ -13,13 +13,17 @@ import DangerousHTML from 'progressive-web-sdk/dist/components/dangerous-html'
 import Badge from '../../components/badge'
 
 const generateCartCounterBadge = (cartContents) => {
-    return cartContents && cartContents.summary_count && cartContents.summary_count > 0 ? (
-        <Badge className="t-header__badge" title={`${cartContents.summary_count} items in the cart`}>
-            {cartContents.summary_count}
-        </Badge>
-    ) : (
-        <p className="u-visually-hidden">No items in the cart.</p>
-    )
+    if (cartContents && cartContents.summary_count && cartContents.summary_count > 0) {
+        return (
+            <Badge className="t-header__badge" title={`${cartContents.summary_count} items in the cart`}>
+                {cartContents.summary_count}
+            </Badge>
+        )
+    } else {
+        return (
+            <p className="u-visually-hidden">No items in the cart.</p>
+        )
+    }
 }
 
 class Header extends React.Component {

--- a/app/containers/header/container.js
+++ b/app/containers/header/container.js
@@ -12,7 +12,7 @@ import logo from '../../static/svg/logo.svg'
 import DangerousHTML from 'progressive-web-sdk/dist/components/dangerous-html'
 import Badge from '../../components/badge'
 
-const generateCartCounterText = (cartContents) => {
+const generateCartCounterBadge = (cartContents) => {
     return cartContents && cartContents.summary_count && cartContents.summary_count > 0 ? (
         <Badge className="t-header__badge" title={`${cartContents.summary_count} items in the cart`}>
             {cartContents.summary_count}
@@ -50,7 +50,7 @@ class Header extends React.Component {
     render() {
         const {onMenuClick, onMiniCartClick} = this.props
         const {isCollapsed, cart} = this.props.header.toJS()
-        const cartCounterText = generateCartCounterText(cart)
+        const cartCounterBadge = generateCartCounterBadge(cart)
 
         const innerButtonClassName = classnames('t-header__inner-button', 'u-padding-0', {
             't--hide-label': isCollapsed
@@ -93,7 +93,7 @@ class Header extends React.Component {
                     <HeaderBarActions>
                         <Button className="u-position-relative" innerClassName={innerButtonClassName} onClick={onMiniCartClick}>
                             <IconLabel label="Cart" iconName="cart" iconSize="medium" />
-                            {cartCounterText}
+                            {cartCounterBadge}
                         </Button>
                     </HeaderBarActions>
                 </HeaderBar>

--- a/app/containers/header/container.js
+++ b/app/containers/header/container.js
@@ -10,11 +10,16 @@ import {HeaderBar, HeaderBarActions, HeaderBarTitle} from 'progressive-web-sdk/d
 import Link from 'progressive-web-sdk/dist/components/link'
 import logo from '../../static/svg/logo.svg'
 import DangerousHTML from 'progressive-web-sdk/dist/components/dangerous-html'
+import Badge from '../../components/badge'
 
 const generateCartCounterText = (cartContents) => {
-    return cartContents && cartContents.summary_count && cartContents.summary_count > 0 ?
-        `Cart - ${cartContents.summary_count}` :
-        'Cart'
+    return cartContents && cartContents.summary_count && cartContents.summary_count > 0 ? (
+        <Badge className="t-header__badge" title={`${cartContents.summary_count} items in the cart`}>
+            {cartContents.summary_count}
+        </Badge>
+    ) : (
+        <p className="u-visually-hidden">No items in the cart.</p>
+    )
 }
 
 class Header extends React.Component {
@@ -86,8 +91,9 @@ class Header extends React.Component {
                     </HeaderBarActions>
 
                     <HeaderBarActions>
-                        <Button innerClassName={innerButtonClassName} onClick={onMiniCartClick}>
-                            <IconLabel label={cartCounterText} iconName="cart" iconSize="medium" />
+                        <Button className="u-position-relative" innerClassName={innerButtonClassName} onClick={onMiniCartClick}>
+                            <IconLabel label="Cart" iconName="cart" iconSize="medium" />
+                            {cartCounterText}
                         </Button>
                     </HeaderBarActions>
                 </HeaderBar>

--- a/app/containers/header/reducer.js
+++ b/app/containers/header/reducer.js
@@ -2,6 +2,7 @@ import Immutable from 'immutable'
 import {createReducer} from 'redux-act'
 // import * as appActions from '../app/actions'
 import * as headerActions from './actions'
+import * as cartActions from '../cart/actions'
 
 export const initialState = Immutable.fromJS({
     isCollapsed: false
@@ -11,6 +12,10 @@ const header = createReducer({
 
     [headerActions.toggleHeader]: (state, payload) => {
         return state.set('isCollapsed', payload.isCollapsed)
+    },
+
+    [cartActions.receiveCartContents]: (state, payload) => {
+        return state.mergeDeep(payload)
     },
 
 }, initialState)

--- a/app/loader-routes.js
+++ b/app/loader-routes.js
@@ -1,4 +1,4 @@
 /* eslint-disable */
 // GENERATED FILE DO NOT EDIT
-const routes = [/^\/\/?$/,/^\/customer\/account\/login\/?$/,/^\/eye-of-newt\.html\/?$/,/^\/unicorn-blood\.html\/?$/,/^\/.*?\.html\/?$/]
+const routes = [/^\/\/?$/,/^\/customer\/account\/login\/?$/,/^\/potions\.html\/?$/,/^\/books\.html\/?$/,/^\/ingredients\.html\/?$/,/^\/supplies\.html\/?$/,/^\/new-arrivals\.html\/?$/,/^\/.*?\.html\/?$/]
 export default routes

--- a/app/styles/_components.scss
+++ b/app/styles/_components.scss
@@ -45,6 +45,7 @@
 // ---
 
 @import '../components/accordion/theme';
+@import '../components/badge/base';
 @import '../components/button/theme';
 @import '../components/carousel/theme';
 @import '../components/divider/theme';


### PR DESCRIPTION
Adds the logic for getting the Cart item count, as well as a badge component.

## Changes
- Add Cart counter logic
- Add Badge component

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=http%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Add a few items to the cart
- Confirm that the Cart count appears on top of the Cart button in the site header

## Todo
- [x] Add any missing tests