### PR TITLE
Update the mini cart on add to cart, and on cart open

### DIFF
--- a/app/containers/app/container.js
+++ b/app/containers/app/container.js
@@ -53,8 +53,8 @@ App.propTypes = {
      * The react-router history object
      */
     history: PropTypes.object,
-    requestOpenMiniCart: PropTypes.func,
     openNavigation: PropTypes.func,
+    requestOpenMiniCart: PropTypes.func,
 }
 
 const mapStateToProps = (state) => {
@@ -64,8 +64,8 @@ const mapStateToProps = (state) => {
 }
 
 const mapDispatchToProps = {
-    requestOpenMiniCart: miniCartActions.requestOpenMiniCart,
     openNavigation: navActions.openNavigation,
+    requestOpenMiniCart: miniCartActions.requestOpenMiniCart,
 }
 
 export default connect(

--- a/app/containers/app/container.js
+++ b/app/containers/app/container.js
@@ -19,7 +19,7 @@ class App extends React.Component {
     }
 
     render() {
-        const {openMiniCart, openNavigation, history} = this.props
+        const {requestOpenMiniCart, openNavigation, history} = this.props
         const currentTemplate = `t-${this.props.children.props.route.routeName}`
 
         return (
@@ -29,7 +29,7 @@ class App extends React.Component {
 
                 <div id="app-wrap" className={currentTemplate}>
                     <div id="app-header" role="banner">
-                        <Header onMenuClick={openNavigation} onMiniCartClick={openMiniCart} />
+                        <Header onMenuClick={openNavigation} onMiniCartClick={requestOpenMiniCart} />
                         <Navigation history={history} />
                         <MiniCart />
                     </div>
@@ -53,7 +53,7 @@ App.propTypes = {
      * The react-router history object
      */
     history: PropTypes.object,
-    openMiniCart: PropTypes.func,
+    requestOpenMiniCart: PropTypes.func,
     openNavigation: PropTypes.func,
 }
 
@@ -64,7 +64,7 @@ const mapStateToProps = (state) => {
 }
 
 const mapDispatchToProps = {
-    openMiniCart: miniCartActions.openMiniCart,
+    requestOpenMiniCart: miniCartActions.requestOpenMiniCart,
     openNavigation: navActions.openNavigation,
 }
 

--- a/app/containers/mini-cart/actions.js
+++ b/app/containers/mini-cart/actions.js
@@ -1,4 +1,10 @@
 import {createAction} from '../../utils/utils'
+import {getCart} from '../cart/actions'
 
 export const openMiniCart = createAction('Open mini-cart')
 export const closeMiniCart = createAction('Close mini-cart')
+
+export const requestOpenMiniCart = () => (dispatch) => {
+    dispatch(getCart())
+    dispatch(openMiniCart())
+}

--- a/app/containers/pdp/actions.js
+++ b/app/containers/pdp/actions.js
@@ -1,4 +1,5 @@
 import {createAction, makeFormEncodedRequest} from '../../utils/utils'
+import {getCart} from '../cart/actions'
 
 export const setItemQuantity = createAction('Set item quantity')
 
@@ -17,5 +18,6 @@ export const submitCartForm = () => (dispatch, getStore) => {
         method: formInfo.get('method')
     }).then(() => {
         dispatch(openItemAddedModal())
+        dispatch(getCart())
     })
 }


### PR DESCRIPTION
Update the mini cart on add to cart, and on cart open

## Changes
- Update the mini cart on add to cart
- Update the mini cart on mini cart open

## How to test-drive this PR
- Add an item to the mini cart
- Observe the mini cart contents
- Add an item to the mini cart in another tab
- Observe the mini cart contents in the original tab after opening

## TODO
- [x] Double-confirm that we want the refresh on mini cart open