### PR TITLE
Service worker for Merlins - Phase 1

### DIFF
--- a/app/loader.js
+++ b/app/loader.js
@@ -13,10 +13,17 @@ const isReactRoute = () => {
 initCacheManifest(cacheHashManifest)
 
 const CAPTURING_CDN = '//cdn.mobify.com/capturejs/capture-latest.min.js'
+const SW_LOADER_PATH = `/service-worker-loader.js?preview=true&b=${cacheHashManifest.buildDate}`
 
 import preloadHTML from 'raw!./preloader/preload.html'
 import preloadCSS from 'css?minimize!./preloader/preload.css'
 import preloadJS from 'raw!./preloader/preload.js' // eslint-disable-line import/default
+
+const loadWorker = () => (
+      navigator.serviceWorker.register(SW_LOADER_PATH)
+        .then(() => navigator.serviceWorker.ready)
+        .catch(() => {})
+)
 
 if (isReactRoute()) {
     displayPreloader(preloadCSS, preloadHTML, preloadJS)
@@ -31,37 +38,44 @@ if (isReactRoute()) {
     loadAsset('meta', {
         name: 'viewport',
         content: 'width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no'
-    })
+    });
     /* eslint-enable max-len */
 
-    loadAsset('link', {
-        href: getAssetUrl('main.css'),
-        rel: 'stylesheet',
-        type: 'text/css',
-        // Tell us when the stylesheet has loaded so we know when it's safe to
-        // display the app! This prevents a flash of unstyled content.
-        onload: 'window.Progressive.stylesheetLoaded = true;'
+    // load the worker if available
+    // if no worker is available, we have to assume that promises might not be either.
+    (('serviceWorker' in navigator)
+     ? loadWorker()
+     : {then: (fn) => setTimeout(fn)}
+    ).then(() => {
+        loadAsset('link', {
+            href: getAssetUrl('main.css'),
+            rel: 'stylesheet',
+            type: 'text/css',
+            // Tell us when the stylesheet has loaded so we know when it's safe to
+            // display the app! This prevents a flash of unstyled content.
+            onload: 'window.Progressive.stylesheetLoaded = true;'
+        })
+
+        const script = document.createElement('script')
+        script.id = 'progressive-web-script'
+        // Setting UTF-8 as our encoding ensures that certain strings (i.e.
+        // Japanese text) are not improperly converted to something else.
+        script.charset = 'utf-8'
+        script.src = getAssetUrl('main.js')
+        body.appendChild(script)
+
+        const jQuery = document.createElement('script')
+        jQuery.async = true
+        jQuery.id = 'progressive-web-jquery'
+        jQuery.src = getAssetUrl('static/js/jquery.min.js')
+        body.appendChild(jQuery)
+
+        const capturing = document.createElement('script')
+        capturing.async = true
+        capturing.id = 'progressive-web-capture'
+        capturing.src = CAPTURING_CDN
+        body.appendChild(capturing)
     })
-
-    const script = document.createElement('script')
-    script.id = 'progressive-web-script'
-    // Setting UTF-8 as our encoding ensures that certain strings (i.e.
-    // Japanese text) are not improperly converted to something else.
-    script.charset = 'utf-8'
-    script.src = getAssetUrl('main.js')
-    body.appendChild(script)
-
-    const jQuery = document.createElement('script')
-    jQuery.async = true
-    jQuery.id = 'progressive-web-jquery'
-    jQuery.src = getAssetUrl('static/js/jquery.min.js')
-    body.appendChild(jQuery)
-
-    const capturing = document.createElement('script')
-    capturing.async = true
-    capturing.id = 'progressive-web-capture'
-    capturing.src = CAPTURING_CDN
-    body.appendChild(capturing)
 } else {
     const capturing = document.createElement('script')
     capturing.async = true

--- a/app/loader.js
+++ b/app/loader.js
@@ -1,4 +1,4 @@
-import {getAssetUrl, loadAsset, initCacheManifest} from 'progressive-web-sdk/dist/asset-utils'
+import {getBuildOrigin, getAssetUrl, loadAsset, initCacheManifest} from 'progressive-web-sdk/dist/asset-utils'
 import {displayPreloader} from 'progressive-web-sdk/dist/preloader'
 import cacheHashManifest from '../tmp/loader-cache-hash-manifest.json'
 
@@ -12,8 +12,11 @@ const isReactRoute = () => {
 
 initCacheManifest(cacheHashManifest)
 
+// This isn't accurate but does describe the case where the PR currently works
+const IS_PREVIEW = getBuildOrigin().indexOf('localhost') !== -1
+
 const CAPTURING_CDN = '//cdn.mobify.com/capturejs/capture-latest.min.js'
-const SW_LOADER_PATH = `/service-worker-loader.js?preview=true&b=${cacheHashManifest.buildDate}`
+const SW_LOADER_PATH = `/service-worker-loader.js?preview=${IS_PREVIEW}&b=${cacheHashManifest.buildDate}`
 
 import preloadHTML from 'raw!./preloader/preload.html'
 import preloadCSS from 'css?minimize!./preloader/preload.css'

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "redux": "3.6.0",
     "redux-act": "1.1.0",
     "redux-thunk": "2.1.0",
+    "sw-toolbox": "3.4.0",
     "whatwg-fetch": "1.0.0"
   },
   "devDependencies": {

--- a/service-worker-loader.js
+++ b/service-worker-loader.js
@@ -1,7 +1,5 @@
 const isPreview = /preview=(true|false)/.exec(self.location.search)[1]
 
-self.importScripts(
-    isPreview === 'true'
-        ? 'https://localhost:8443/worker.js'
-        : 'https://cdn.mobify.com/stuff'
-)
+if (isPreview) {
+    self.importScripts('https://localhost:8443/worker.js')
+}

--- a/service-worker-loader.js
+++ b/service-worker-loader.js
@@ -1,5 +1,6 @@
+// THIS IS A STRING VALUE NOT A BOOLEAN
 const isPreview = /preview=(true|false)/.exec(self.location.search)[1]
 
-if (isPreview) {
+if (isPreview === 'true') {
     self.importScripts('https://localhost:8443/worker.js')
 }

--- a/service-worker-loader.js
+++ b/service-worker-loader.js
@@ -1,0 +1,7 @@
+const isPreview = /preview=(true|false)/.exec(self.location.search)[1]
+
+self.importScripts(
+    isPreview === 'true'
+        ? 'https://localhost:8443/worker.js'
+        : 'https://cdn.mobify.com/stuff'
+)

--- a/worker/main.js
+++ b/worker/main.js
@@ -1,1 +1,14 @@
-console.log('Worker running')
+/* global PROJECT_SLUG, DEBUG */
+/* eslint-env worker, serviceworker */
+
+import toolbox from 'sw-toolbox'
+
+// Configuration options
+const version = '0.1.0'
+const precacheUrls = []
+
+// Derived constants
+const baseCacheName = `${PROJECT_SLUG}-v${version}`
+toolbox.options.cache.name = baseCacheName
+toolbox.options.cache.maxAgeSeconds = 86400
+toolbox.debug = DEBUG

--- a/worker/main.js
+++ b/worker/main.js
@@ -12,7 +12,7 @@ const manifest = {}
 const baseCacheName = `${PROJECT_SLUG}-v${version}`
 toolbox.options.cache.name = baseCacheName
 toolbox.options.cache.maxAgeSeconds = 86400
-toolbox.debug = DEBUG
+toolbox.options.debug = DEBUG
 
 // No cache maintenance options here on purpose,
 // this is a permanent cache

--- a/worker/main.js
+++ b/worker/main.js
@@ -6,22 +6,21 @@ import toolbox from 'sw-toolbox'
 const cachebreaker = /b=([^&]+)/.exec(self.location.search)[1]
 const CAPTURING_URL = 'https://cdn.mobify.com/capturejs/capture-latest.min.js'
 
-// Configuration options
 const version = '0.1.0'
+// For offline mode this needs to store the main.js, main.css, loader,
+// and capturing in the bundle cache. For now we can't due to CORS limitations
 const precacheUrls = [
-    `https://localhost:8443/main.css?${cachebreaker}`,
-    `https://localhost:8443/main.js?${cachebreaker}`
+    // `https://localhost:8443/main.css?${cachebreaker}`,
+    // `https://localhost:8443/main.js?${cachebreaker}`
 ]
 const manifest = {}
 
-// Derived constants
 const baseCacheName = `${PROJECT_SLUG}-v${version}`
 toolbox.options.cache.name = baseCacheName
 toolbox.options.cache.maxAgeSeconds = 86400
 toolbox.options.debug = DEBUG
 
-// No cache maintenance options here on purpose,
-// this is a permanent cache
+// No cache maintenance options here on purpose, this is a permanent cache
 const bundleCache = {
     name: `${baseCacheName}-bundle-${cachebreaker}`
 }
@@ -79,6 +78,7 @@ toolbox.router.get(/\.(?:png|gif|svg|jpe?g)$/, toolbox.fastest, {cache: imageCac
 toolbox.router.get(/cdn\.mobify\.com\/.*\?[a-f\d]+$/, toolbox.cacheFirst, {cache: bundleCache})
 toolbox.router.get(/localhost:8443.*\?[a-f\d]+$/, toolbox.networkFirst, {cache: bundleCache})
 toolbox.router.get(new RegExp(`^${CAPTURING_URL}$`), toolbox.networkFirst, {cache: bundleCache})
+toolbox.router.get(/cdn\.mobify\.com\/.*loader\.js$/, toolbox.networkFirst, {cache: bundleCache})
 
 
-// toolbox.router.default = toolbox.networkFirst
+toolbox.router.default = toolbox.networkFirst

--- a/worker/main.js
+++ b/worker/main.js
@@ -12,3 +12,23 @@ const baseCacheName = `${PROJECT_SLUG}-v${version}`
 toolbox.options.cache.name = baseCacheName
 toolbox.options.cache.maxAgeSeconds = 86400
 toolbox.debug = DEBUG
+// Lifecycle Handlers
+
+self.addEventListener('install', (e) => {
+    e.waitUntil(
+        self.skipWaiting()
+            .then(() => console.log('[ServiceWorker] Installed version', version))
+    )
+})
+
+self.addEventListener('activate', (e) => {
+    e.waitUntil(
+        self.clients.claim()
+            .then(() => caches.keys())
+            .then((cacheKeys) => cacheKeys.filter(
+                (key) => !key.startsWith(baseCacheName) && !key.endsWith('$$$inactive$$$')))
+            .then((keysToDelete) => keysToDelete.map((key) => caches.delete(key)))
+            .then((promises) => Promise.all(promises))
+    )
+})
+

--- a/worker/main.js
+++ b/worker/main.js
@@ -77,7 +77,7 @@ toolbox.router.get('/manifest.json', () => {
 toolbox.router.get(/\.(?:png|gif|svg|jpe?g)$/, toolbox.fastest, {cache: imageCache})
 
 toolbox.router.get(/cdn\.mobify\.com\/.*\?[a-f\d]+$/, toolbox.cacheFirst, {cache: bundleCache})
-toolbox.router.get(/localhost:8443.*\?[a-f\d]+$/, toolbox.cacheFirst, {cache: bundleCache})
+toolbox.router.get(/localhost:8443.*\?[a-f\d]+$/, toolbox.networkFirst, {cache: bundleCache})
 toolbox.router.get(new RegExp(`^${CAPTURING_URL}$`), toolbox.networkFirst, {cache: bundleCache})
 
 

--- a/worker/main.js
+++ b/worker/main.js
@@ -6,12 +6,29 @@ import toolbox from 'sw-toolbox'
 // Configuration options
 const version = '0.1.0'
 const precacheUrls = []
+const manifest = {}
 
 // Derived constants
 const baseCacheName = `${PROJECT_SLUG}-v${version}`
 toolbox.options.cache.name = baseCacheName
 toolbox.options.cache.maxAgeSeconds = 86400
 toolbox.debug = DEBUG
+
+// Utility functions
+const jsonResponse = (data) => {
+    return new Response(
+        new Blob(
+            [JSON.stringify(data)],
+            {type: 'application/json'}
+        ),
+        {
+            status: 200,
+            statusText: 'OK'
+        }
+    )
+}
+
+
 // Lifecycle Handlers
 
 self.addEventListener('install', (e) => {
@@ -32,3 +49,7 @@ self.addEventListener('activate', (e) => {
     )
 })
 
+// Path Handlers
+toolbox.router.get('/manifest.json', () => {
+    return jsonResponse(manifest)
+})

--- a/worker/main.js
+++ b/worker/main.js
@@ -14,6 +14,21 @@ toolbox.options.cache.name = baseCacheName
 toolbox.options.cache.maxAgeSeconds = 86400
 toolbox.debug = DEBUG
 
+// No cache maintenance options here on purpose,
+// this is a permanent cache
+// NOTE: This should eventually have some sort of bundle identifier
+// so that we throw it away when the bundle changes
+const bundleCache = {
+    name: `${baseCacheName}-bundle`
+}
+
+const imageCache = {
+    name: `${baseCacheName}-images`,
+    maxEntries: 40
+}
+
+toolbox.precache(precacheUrls)
+
 // Utility functions
 const jsonResponse = (data) => {
     return new Response(
@@ -53,3 +68,10 @@ self.addEventListener('activate', (e) => {
 toolbox.router.get('/manifest.json', () => {
     return jsonResponse(manifest)
 })
+
+toolbox.router.get(/\.(?:png|gif|svg|jpe?g)$/, toolbox.fastest, {cache: imageCache})
+
+toolbox.router.get(/cdn\.mobify\.com\/.*\?[a-f\d]+$/, toolbox.cacheFirst, {cache: bundleCache})
+toolbox.router.get(/localhost:8443.*\?[a-f\d]+$/, toolbox.cacheFirst, {cache: bundleCache})
+
+// toolbox.router.default = toolbox.networkFirst


### PR DESCRIPTION
We need a service worker for Merlin's Potions to increase performance, improve our Lighthouse score, and enable offline mode and add to homescreen on Chrome. This PR will add one, along with the machinery needed to load it.

Functionality:
 - A 'bundle cache' for bundle contents, that prevents requests from going onto the network.
 - An image cache, for the 40 most recent images loaded. These images are served by the cache but updated from the network in the background.
 - A general cache for all other content, with an expiration of 24 hours for content.

The current PR only works for local preview, production support will be added in a follow-up.

 **JIRA**: https://mobify.atlassian.net/browse/WEB-991
 **Linked PRs**: #193 

## Changes
- Add a service worker build configuration
- Add a service worker file
- Load the worker in the app initialization
- Enable caches

## How to test-drive this PR
- Use Charles to map the file `service-worker-loader.js` to `https://www.merlinspotions.com/service-worker-loader.js`.
- Load the site and see that a service worker is available in the Application tag of dev tools
- Reload the page with the Network tab open and see the lack of network requests for bundle resources
- Look in the Application tab at the Browser Cache, and see the multiple caches managed by the worker.