### PR TITLE
Release Patch: Remove unnecessary CSS import

### DIFF
--- a/app/styles/_components.scss
+++ b/app/styles/_components.scss
@@ -5,4 +5,3 @@
 
 @import '../components/icon-label-button/base';
 @import '../components/product-item/base';
-@import '../components/skip-links/base';


### PR DESCRIPTION
I missed removing this import from today's earlier release of 0.10.4