### PR TITLE
Improve preview SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,26 @@ To run tests in watch mode and only run test related to files you modify during 
 npm run test:watch
 ```
 
+## Prevent SSL Errors in Preview (on a Mac)
+
+The development server uses a self-signed SSL certificate which is
+valid, but treated as suspect by browsers. This means that we must
+create and reconfirm security exceptions for it, and avoid localhost
+for certain use cases (such as service workers).
+
+To add the certificate to the Mac system trust store and make the
+browsers accept it, do the following:
+
+1. In the root of the project directory, run `open node_modules/webpack-dev-server/ssl/server.crt`.
+2. Open `Keychain Access` -> go to `Certificates` -> select `localhost`
+3. Right click on the entry and select `Get Info`
+4. Expand the `Trust` section
+5. Set `Secure Socket Layer (SSL)` to `Always Trust`
+6. Close the info window. You will need to enter your password.
+
+This process will allow all projects hosted with `webpack-dev-server`
+version 1.15.0 and up to be trusted by your browsers.
+
 ## Automated end-to-end tests
 
 To verify that changes do not break the checkout flow:

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "text-loader": "0.0.1",
     "validator": "6.1.0",
     "webpack": "1.13.2",
-    "webpack-dev-server": "1.14.1",
+    "webpack-dev-server": "1.16.2",
     "webpack-hot-middleware": "2.13.0"
   },
   "scripts": {


### PR DESCRIPTION
The certificate shipped with version 1.14.1 of `webpack-dev-server` is expired, as of March this year. This PR updates to a newer version with a non-expired cert.

With this PR in place, the `node_modules/webpack-dev-server/ssl/server.crt` certificate can be added to the trust store of a Mac to avoid having to re-confirm SSL exceptions for any progressive build with this change.