### PR TITLE
Tweak skeleton animations

### DIFF
--- a/app/containers/home/partials/home-carousel.jsx
+++ b/app/containers/home/partials/home-carousel.jsx
@@ -22,6 +22,7 @@ const HomeCarousel = ({banners}) => {
                                 <Image
                                     src={getAssetUrl(`static/img/homepage_carousel/${key}.png`)}
                                     alt={alt}
+                                    className="u-block"
                                     hidePlaceholder={true}
                                     loadingIndicator={placeholder}
                                 />

--- a/app/containers/mini-cart/container.js
+++ b/app/containers/mini-cart/container.js
@@ -58,7 +58,7 @@ class MiniCart extends React.Component {
                             title={<h2 className="u-h3">{product.product_name}</h2>}
                             price={product.product_price}
                             key={idx}
-                            image={<Image src={product.product_image.src} alt={product.product_image.alt} width="64px" />}
+                            image={<Image src={product.product_image.src} alt={product.product_image.alt} width="64px" height="64px" />}
                         >
                             <div>
                                 <p className="u-margin-bottom-sm">Qty: {product.qty}</p>

--- a/app/containers/pdp/partials/pdp-carousel.jsx
+++ b/app/containers/pdp/partials/pdp-carousel.jsx
@@ -15,6 +15,7 @@ const PDPCarousel = ({items}) => {
                         <Image
                             alt={alt}
                             src={item.img}
+                            className="u-block"
                             hidePlaceholder={true}
                             loadingIndicator={<SkeletonBlock height="100vw" />} />
                     </CarouselItem>

--- a/app/styles/_utilities.scss
+++ b/app/styles/_utilities.scss
@@ -2,10 +2,11 @@
 // ===
 
 @import 'utilities/border';
-@import 'utilities/card';
 @import 'utilities/box-shadow';
+@import 'utilities/card';
 @import 'utilities/color';
 @import 'utilities/dimensions';
+@import 'utilities/display';
 @import 'utilities/flexbox';
 @import 'utilities/heading';
 @import 'utilities/layout';

--- a/app/styles/animations/_background.scss
+++ b/app/styles/animations/_background.scss
@@ -9,10 +9,10 @@
 
 @keyframes background-shimmer {
     0% {
-        background-position: 100% 0;
+        transform: translateX(-5000%);
     }
 
     to {
-        background-position: -100% 0;
+        transform: translateX(5000%);
     }
 }

--- a/app/styles/lib/_background.scss
+++ b/app/styles/lib/_background.scss
@@ -5,12 +5,6 @@
 // ---
 
 @mixin background-shimmer() {
-    // background: $neutral-30;
-    // background-image: linear-gradient(to left, $neutral-30, scale-color($neutral-30, $lightness: -5%) 20%, $neutral-30 40%, $neutral-30);
-    // background-repeat: no-repeat;
-    // background-size: 600% 600%;
-    //
-    // animation: 1.5s linear infinite forwards background-shimmer;
     overflow: hidden;
 
     background: rgba(0, 0, 0, 0.03);

--- a/app/styles/lib/_background.scss
+++ b/app/styles/lib/_background.scss
@@ -5,10 +5,26 @@
 // ---
 
 @mixin background-shimmer() {
-    background: $neutral-30;
-    background-image: linear-gradient(to left, $neutral-30, scale-color($neutral-30, $lightness: -5%) 20%, $neutral-30 40%, $neutral-30);
-    background-repeat: no-repeat;
-    background-size: 600% 600%;
+    // background: $neutral-30;
+    // background-image: linear-gradient(to left, $neutral-30, scale-color($neutral-30, $lightness: -5%) 20%, $neutral-30 40%, $neutral-30);
+    // background-repeat: no-repeat;
+    // background-size: 600% 600%;
+    //
+    // animation: 1.5s linear infinite forwards background-shimmer;
+    overflow: hidden;
 
-    animation: 1.5s linear infinite forwards background-shimmer;
+    background: rgba(0, 0, 0, 0.03);
+
+    &::after {
+        content: '';
+
+        display: inline-block;
+        width: 10px;
+        height: 100%;
+
+        background: rgba(0, 0, 0, 0.05);
+        box-shadow: 0 0 100px 75px rgba(0, 0, 0, 0.05);
+
+        animation: 1.5s linear infinite background-shimmer;
+    }
 }

--- a/app/styles/themes/pw-components/_skeleton-inline.scss
+++ b/app/styles/themes/pw-components/_skeleton-inline.scss
@@ -2,7 +2,9 @@
 // ===
 
 .pw-skeleton-inline {
-    &::after {
-        @include background-shimmer;
-    }
+    @include background-shimmer;
+
+    // &::after {
+    //     @include background-shimmer;
+    // }
 }

--- a/app/styles/themes/pw-components/_skeleton-inline.scss
+++ b/app/styles/themes/pw-components/_skeleton-inline.scss
@@ -3,8 +3,4 @@
 
 .pw-skeleton-inline {
     @include background-shimmer;
-
-    // &::after {
-    //     @include background-shimmer;
-    // }
 }

--- a/app/styles/utilities/_display.scss
+++ b/app/styles/utilities/_display.scss
@@ -1,0 +1,10 @@
+// Display
+// ===
+
+
+// Display: Block
+// ---
+
+.u-block {
+    display: block !important; // @TODO: Add to Spline
+}


### PR DESCRIPTION
Soften the skeleton animation colors and improve performance for some browsers.

## Changes
- Switch `background-position` to animation to `transform` (drastically reduce paints)
- Switch from background gradient to `box-shadow`
- Switch from solid colors to opaque

## How to test-drive this PR
- Run `npm run dev`
- [Preview Merlin's Potions](https://preview.mobify.com/?url=http%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Verify the skeleton animations look good