### PR TITLE
Service worker build infrastructure

### DIFF
--- a/webpack/base.worker.js
+++ b/webpack/base.worker.js
@@ -1,7 +1,7 @@
 /* eslint-env node */
 /* eslint-disable import/no-commonjs */
 
-// const webpack = require('webpack')
+const webpack = require('webpack')
 const path = require('path')
 
 module.exports = {
@@ -10,6 +10,11 @@ module.exports = {
         path: path.resolve(process.cwd(), 'build'),
         filename: 'worker.js'
     },
+    plugins: [
+        new webpack.DefinePlugin({
+            PROJECT_SLUG: JSON.stringify(require('../package.json').name) // eslint-disable-line import/no-extraneous-dependencies
+        })
+    ],
     module: {
         loaders: [{
             name: 'babel-loader',

--- a/webpack/base.worker.js
+++ b/webpack/base.worker.js
@@ -1,0 +1,24 @@
+/* eslint-env node */
+/* eslint-disable import/no-commonjs */
+
+// const webpack = require('webpack')
+const path = require('path')
+
+module.exports = {
+    entry: './worker/main.js',
+    output: {
+        path: path.resolve(process.cwd(), 'build'),
+        filename: 'worker.js'
+    },
+    module: {
+        loaders: [{
+            name: 'babel-loader',
+            test: /\.js$/,
+            exclude: /node_modules/,
+            loaders: [
+                'babel'
+            ],
+            cacheDirectory: path.join(__dirname, 'tmp')
+        }]
+    }
+}

--- a/webpack/dev.js
+++ b/webpack/dev.js
@@ -24,4 +24,10 @@ mainConfig.plugins = mainConfig.plugins.concat([
     new webpack.NoErrorsPlugin()
 ])
 
+workerConfig.plugins = workerConfig.plugins.concat([
+    new webpack.DefinePlugin({
+        DEBUG: true
+    })
+])
+
 module.exports = [mainConfig, loaderConfig, workerConfig]

--- a/webpack/dev.js
+++ b/webpack/dev.js
@@ -5,6 +5,7 @@ const ip = require('ip')
 
 const loaderConfig = require('./base.loader')
 const mainConfig = require('./base.main')
+const workerConfig = require('./base.worker')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 
 mainConfig.module.loaders = mainConfig.module.loaders.concat({
@@ -23,4 +24,4 @@ mainConfig.plugins = mainConfig.plugins.concat([
     new webpack.NoErrorsPlugin()
 ])
 
-module.exports = [mainConfig, loaderConfig]
+module.exports = [mainConfig, loaderConfig, workerConfig]

--- a/webpack/production.js
+++ b/webpack/production.js
@@ -6,6 +6,7 @@ const assign = require('lodash.assign')
 
 const baseLoaderConfig = require('./base.loader')
 const baseMainConfig = require('./base.main')
+const workerConfig = require('./base.worker')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 
 // Add production flag to main app config
@@ -27,4 +28,10 @@ baseMainConfig.module.loaders = baseMainConfig.module.loaders.concat({
     ]
 })
 
-module.exports = [productionMainConfig, baseLoaderConfig]
+workerConfig.plugins = workerConfig.plugins.concat([
+    new webpack.DefinePlugin({
+        DEBUG: false
+    })
+])
+
+module.exports = [productionMainConfig, baseLoaderConfig, workerConfig]

--- a/worker/main.js
+++ b/worker/main.js
@@ -1,0 +1,1 @@
+console.log('Worker running')


### PR DESCRIPTION
Adds the Webpack scripts necessary for building a service worker, and a stub service worker for them to build.

 **JIRA**: Contributes to https://mobify.atlassian.net/browse/WEB-991
 **Linked PRs**: https://github.com/mobify/progressive-web-scaffold/pull/175

## Changes
- Add dev and production build scripts for the service worker.

## How to test-drive this PR
- npm run dev
- see that http://localhost:8443/worker.js exists
- npm run prod:build
- see that there is a worker.js in the build directory.