### PR TITLE
Update logger.js

### DIFF
--- a/dev-server/logger.js
+++ b/dev-server/logger.js
@@ -33,7 +33,7 @@ const logger = {
 
         console.log(
             chalk.bold('Preview URL: ') + // eslint-disable-line prefer-template
-            chalk.magenta(`https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A${port}%2Floader.js&disabled=0&domain=&scope=1`) + '\n' +
+            chalk.magenta(`https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A${port}%2Floader.js&disabled=0&domain=&scope=0`) + '\n' +
             divider + '\n' +
             chalk.blue(`Press ${chalk.italic('CTRL-C')} to stop`) + '\n'
         )


### PR DESCRIPTION
## Changes
- Currently, the preview link we generate defaults to "This Tab". But the downside to limiting it to single tab is that when you preview and cross between HTTP and HTTPS, you have to re-preview. "All Tabs" solves this problem. (the background reason is that "This Tab" uses LocalStorage to store the bundle cookie, which isn't shared across HTTP and HTTPS, where as "All Tabs" stores the bundle string in a cookie).

## How to test-drive this PR
- Run `npm run dev`, copy the preview URL, make sure it defaults to "All Tabs" by looking at which radio button is selected by default.

