### PR TITLE
Support for using a custom a.js slug

### DIFF
--- a/app/main.jsx
+++ b/app/main.jsx
@@ -20,7 +20,7 @@ import {initMobifyAnalytics} from 'progressive-web-sdk/dist/analytics'
 
 polyfill()
 
-initMobifyAnalytics(PROJECT_SLUG) // eslint-disable-line no-undef
+initMobifyAnalytics(AJS_SLUG) // eslint-disable-line no-undef
 initCacheManifest(cacheHashManifest)
 
 const store = configureStore()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "progressive-web-scaffold",
   "projectSlug": "progressive-web-scaffold",
+  "aJSSlug": "merlinspotions-2",
   "repository": {
     "type": "git",
     "url": "http://github.com/mobify/progressive-web-scaffold"

--- a/webpack/base.main.js
+++ b/webpack/base.main.js
@@ -35,7 +35,8 @@ module.exports = {
             {from: 'app/static/', to: 'static/'}
         ]),
         new webpack.DefinePlugin({
-            PROJECT_SLUG: JSON.stringify(require('../package.json').projectSlug) // eslint-disable-line import/no-extraneous-dependencies
+            PROJECT_SLUG: JSON.stringify(require('../package.json').projectSlug), // eslint-disable-line import/no-extraneous-dependencies
+            AJS_SLUG: JSON.stringify(require('../package.json').aJSSlug) // eslint-disable-line import/no-extraneous-dependencies
         })
     ],
     module: {


### PR DESCRIPTION
Since we need web push to still work for demos on Merlins Potions, and we are using a different cloud project than what is live (and is set up for web push) - we need to load the a.js file from a different slug. 

 **JIRA**: https://mobify.atlassian.net/browse/WEB-992
 **Linked PRs**: #190, #195

## Changes
- Support for separate a.js slug in `package.json` and used in `main.jsx`

## How to test-drive this PR
- Preview
- Observe a.js loads from the right place (check the Network Debug Panel)