### PR TITLE
Bundle analyzer improvements

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,10 @@
   ],
   "plugins": [
     "transform-object-rest-spread",
-    "transform-object-assign"
+    "transform-object-assign",
+    ["transform-runtime", {
+      "polyfill": false,
+      "regenerator": false
+    }]
   ]
 }

--- a/app/containers/login/actions.js
+++ b/app/containers/login/actions.js
@@ -1,5 +1,5 @@
 import {createAction, makeFormEncodedRequest} from '../../utils/utils'
-import {isEmail} from 'validator'
+import isEmail from 'validator/lib/isEmail'
 import {SubmissionError} from 'redux-form'
 
 const validateSignInForm = (formValues) => {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "private": true,
   "version": "0.9.1",
   "dependencies": {
+    "babel-runtime": "6.11.6",
     "es6-promise": "4.0.5",
     "immutable": "3.8.1",
     "react": "15.3.2",
@@ -30,6 +31,7 @@
     "babel-loader": "6.2.5",
     "babel-plugin-transform-object-assign": "6.8.0",
     "babel-plugin-transform-object-rest-spread": "6.16.0",
+    "babel-plugin-transform-runtime": "6.15.0",
     "babel-polyfill": "6.16.0",
     "babel-preset-es2015": "6.16.0",
     "babel-preset-react": "6.16.0",


### PR DESCRIPTION
This PR improves our build size in some simple ways.

 **JIRA**: N/A

## Changes
- Import only the necessary part of the `validator` package, saving 65KB uncompressed
- Use the Babel runtime transform to deduplicate glue code, saving 20KB uncompressed

## How to test-drive this PR
- Run the tests
- Preview the bundle, see that nothing's changed