### PR TITLE
Revert back to CircleCI Classic.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
 test:
     override:
         - npm run lint
-        - npm run test:all
+        - npm test -- --runInBand
         # Enable smoke-test when automated workflow tests have been implemented.
         # - npm run smoke-test
         #    parallel: true

--- a/circle.yml
+++ b/circle.yml
@@ -1,34 +1,22 @@
-version: 2
-executorType: docker
-containerInfo:
-  - image: node:6.9.2
-stages:
-  build:
-    workDir: /home/ubuntu/progressive-web-scaffold
-    steps:
-      - type: checkout
-      - type: shell
-        name: Pre-Dep
-        command: mkdir /home/ubuntu/artifacts
-      - type: cache-restore
-        key: progressive-web-scaffold-{{ .Branch }}
-      - type: shell
-        name: Install Chrome
-        command: |
-          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-          sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-          apt-get update
-          apt-get --only-upgrade install google-chrome-stable
-      - type: shell
-        name: Install Dependencies
-        command: npm install
-      - type: cache-save
-        key: progressive-web-scaffold-{{ .Branch }}
-        paths:
-          - /home/ubuntu/progressive-web-scaffold/node_modules
-      - type: shell
-        name: NPM Test
-        command: npm run test:all
-      - type: artifacts-store
-        path: coverage/
-        destination: test-coverage
+machine:
+    node:
+        version: 6.9.2
+dependencies:
+    pre:
+        - wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+        - sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+        - sudo apt-get update
+        - sudo apt-get --only-upgrade install google-chrome-stable
+test:
+    override:
+        - npm run lint
+        - npm test -- --runInBand
+        # Enable smoke-test when automated workflow tests have been implemented.
+        # - npm run smoke-test
+        #    parallel: true
+experimental:
+    notify:
+        branches:
+            only:
+                - master
+                - develop

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
 test:
     override:
         - npm run lint
-        - npm test -- --runInBand
+        - npm test:all
         # Enable smoke-test when automated workflow tests have been implemented.
         # - npm run smoke-test
         #    parallel: true

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
 test:
     override:
         - npm run lint
-        - npm test:all
+        - npm run test:all
         # Enable smoke-test when automated workflow tests have been implemented.
         # - npm run smoke-test
         #    parallel: true


### PR DESCRIPTION
Two main reasons for this change:
- Progressive Mobile is becoming part of this repo.
- We run into some issues with the new Lighthouse tests on CircleCI 2.0

Based on the above, now is not a good time to migrate to a new CI platform that hasn't been publicly released.

## How to test-drive this PR
- Make sure CircleCI tests pass.
