### PR TITLE
Implement pop-to-root when tapping already-selected tab

### DIFF
--- a/native/app/controllers/tabBarController.js
+++ b/native/app/controllers/tabBarController.js
@@ -38,22 +38,17 @@ TabBarController.init = async function() {
 }
 
 TabBarController.prototype._tabSelected = function(tabId) {
+    const newTabController = this._tabControllers[tabId]
     if (this.activeTabId !== tabId) {
-        // activeTabId is undefined during startup
         const oldTabController = this.getActiveController()
         if (oldTabController) {
             oldTabController.deactivate()
         }
 
         this.activeTabId = tabId
-        const activeTabController = this._tabControllers[tabId]
-
-        activeTabController.activate()
-
-        this.viewPlugin.setContentView(activeTabController.viewPlugin)
-    } else {
-        this.getActiveNavigationView().popToRoot({animated: true})
+        this.viewPlugin.setContentView(newTabController.viewPlugin)
     }
+    newTabController.activate()
 }
 
 TabBarController.prototype.selectTab = function(tabId) {

--- a/native/app/controllers/tabController.js
+++ b/native/app/controllers/tabController.js
@@ -61,15 +61,19 @@ TabController.prototype.reload = async function() {
     this.loaded = true
 }
 
-TabController.prototype.activate = async function() {
-    this.isActive = true
+TabController.prototype.activate = function() {
+    if (this.isActive) {
+        this.navigationView.popToRoot({animated: true})
+    } else {
+        this.isActive = true
 
-    if (!this.loaded) {
-        await this.reload()
+        if (!this.loaded) {
+            this.reload()
+        }
     }
 }
 
-TabController.prototype.deactivate = async function() {
+TabController.prototype.deactivate = function() {
     this.isActive = false
 }
 


### PR DESCRIPTION
Implements the pop-to-root when tapping on the tab you're already on. `TabController` owns this behaviour now.

 **JIRA**: (link to JIRA ticket)
 **Linked PRs**: (links to corresponding PRs, optional)

## Changes
- (change1)

## How to test-drive this PR
- (necessary config changes)
- (necessary corresponding PRs)
- (how to access the new / changed functionality -- fixtures, URLs)
