### PR TITLE
Rename astro to progressive-app-sdk in the imports

### DIFF
--- a/native/app/app.js
+++ b/native/app/app.js
@@ -1,9 +1,9 @@
 /* global AstroNative */
 
 // Astro
-import Application from 'astro/application'
-import MobifyPreviewPlugin from 'astro/plugins/mobifyPreviewPlugin'
-import PreviewController from 'astro/controllers/previewController'
+import Application from 'progressive-app-sdk/application'
+import MobifyPreviewPlugin from 'progressive-app-sdk/plugins/mobifyPreviewPlugin'
+import PreviewController from 'progressive-app-sdk/controllers/previewController'
 
 import baseConfig from './config/baseConfig'
 import TabBarController from './controllers/tabBarController'

--- a/native/app/config/baseConfig.js
+++ b/native/app/config/baseConfig.js
@@ -1,6 +1,6 @@
 /* global AstroNative */
 
-import Astro from 'astro/astro-full'
+import Astro from 'progressive-app-sdk/astro-full'
 
 // TODO: Update <local_ip> if running on Android
 const localPreviewUrl = Astro.isRunningInIOSApp()

--- a/native/app/config/tabBarConfig.js
+++ b/native/app/config/tabBarConfig.js
@@ -1,3 +1,4 @@
+
 const tabBarConfig = {
     items: [
         {

--- a/native/app/controllers/tabBarController.js
+++ b/native/app/controllers/tabBarController.js
@@ -1,5 +1,5 @@
-import AnchoredLayoutPlugin from 'astro/plugins/anchoredLayoutPlugin'
-import TabBarPlugin from 'astro/plugins/tabBarPlugin'
+import AnchoredLayoutPlugin from 'progressive-app-sdk/plugins/anchoredLayoutPlugin'
+import TabBarPlugin from 'progressive-app-sdk/plugins/tabBarPlugin'
 
 import {tabBarConfig} from '../config/tabBarConfig'
 import TabController from './tabController'

--- a/native/app/controllers/tabController.js
+++ b/native/app/controllers/tabController.js
@@ -1,8 +1,8 @@
 import Promise from 'bluebird'
 
-import AnchoredLayoutPlugin from 'astro/plugins/anchoredLayoutPlugin'
-import HeaderBarPlugin from 'astro/plugins/headerBarPlugin'
-import NavigationPlugin from 'astro/plugins/navigationPlugin'
+import AnchoredLayoutPlugin from 'progressive-app-sdk/plugins/anchoredLayoutPlugin'
+import HeaderBarPlugin from 'progressive-app-sdk/plugins/headerBarPlugin'
+import NavigationPlugin from 'progressive-app-sdk/plugins/navigationPlugin'
 
 const TabController = function(tabItem, layout, headerBar, navigationView) {
     this.tabItem = tabItem

--- a/native/webpack.app.config.js
+++ b/native/webpack.app.config.js
@@ -22,7 +22,7 @@ var config = {
     },
     resolve: {
         alias: {
-            astro: path.resolve(rootDir, 'node_modules/mobify-progressive-app-sdk/js/src/'),
+            'progressive-app-sdk': path.resolve(rootDir, 'node_modules/mobify-progressive-app-sdk/js/src/'),
             vendor: path.resolve(rootDir, 'node_modules/mobify-progressive-app-sdk/js/vendor/'),
             bluebird: path.resolve(rootDir, 'node_modules/bluebird')
         },


### PR DESCRIPTION
Renames the alias for webpack from `astro` to `progressive-app-sdk`

## Changes
- Rename the alias
- Go through each import and fix

## How to test-drive this PR
- Run the app and navigate around
