### PR TITLE
Ensure offline homescreen survives cache expiry

### DIFF
--- a/service-worker-loader.js
+++ b/service-worker-loader.js
@@ -3,4 +3,6 @@ const isPreview = /preview=(true|false)/.exec(self.location.search)[1]
 
 if (isPreview === 'true') {
     self.importScripts('https://localhost:8443/worker.js')
+} else {
+    self.importScripts('https://cdn.mobify.com/sites/progressive-web-scaffold/production/worker.js')
 }

--- a/worker/main.js
+++ b/worker/main.js
@@ -6,7 +6,7 @@ import toolbox from 'sw-toolbox'
 const cachebreaker = /b=([^&]+)/.exec(self.location.search)[1]
 const CAPTURING_URL = 'https://cdn.mobify.com/capturejs/capture-latest.min.js'
 
-const version = '0.1.1'
+const version = '0.1.2'
 // For offline mode this needs to store the main.js, main.css, loader,
 // and capturing in the bundle cache. For now we can't due to CORS limitations
 const precacheUrls = [
@@ -56,10 +56,21 @@ self.addEventListener('activate', (e) => {
 // Path Handlers
 toolbox.router.get(/\.(?:png|gif|svg|jpe?g)$/, toolbox.fastest, {cache: imageCache})
 
+// Bundle contents
 toolbox.router.get(/cdn\.mobify\.com\/.*\?[a-f\d]+$/, toolbox.cacheFirst, {cache: bundleCache})
 toolbox.router.get(/localhost:8443.*\?[a-f\d]+$/, toolbox.networkFirst, {cache: bundleCache})
-toolbox.router.get(new RegExp(`^${CAPTURING_URL}$`), toolbox.networkFirst, {cache: bundleCache})
-toolbox.router.get(/cdn\.mobify\.com\/.*loader\.js$/, toolbox.networkFirst, {cache: bundleCache})
+// Keep the preview response around for offline in preview mode
+toolbox.router.get(/https:\/\/preview.mobify.com\/v7/, toolbox.networkFirst, {cache: bundleCache})
 
+// Necessary Mobify scripts
+toolbox.router.get(new RegExp(`^${CAPTURING_URL}$`), toolbox.networkFirst, {cache: bundleCache})
+toolbox.router.get(/(?:cdn\.mobify\.com|localhost:8443)\/.*loader\.js$/, toolbox.networkFirst, {cache: bundleCache})
+
+// Google fonts
+toolbox.router.get(/fonts.gstatic.com\/.*\.woff2$/, toolbox.cacheFirst, {cache: bundleCache})
+toolbox.router.get(/fonts.googleapis.com\/css/, toolbox.networkFirst, {cache: bundleCache})
+
+// Main page is needed for offline
+toolbox.router.get('/', toolbox.networkFirst, {cache: bundleCache})
 
 toolbox.router.default = toolbox.networkFirst

--- a/worker/main.js
+++ b/worker/main.js
@@ -70,7 +70,7 @@ toolbox.router.get(/(?:cdn\.mobify\.com|localhost:8443)\/.*loader\.js$/, toolbox
 toolbox.router.get(/fonts.gstatic.com\/.*\.woff2$/, toolbox.cacheFirst, {cache: bundleCache})
 toolbox.router.get(/fonts.googleapis.com\/css/, toolbox.networkFirst, {cache: bundleCache})
 
-// Main page is needed for offline
+// Main page is needed for installed app when offline
 toolbox.router.get('/', toolbox.networkFirst, {cache: bundleCache})
 
 toolbox.router.default = toolbox.networkFirst


### PR DESCRIPTION
This PR makes sure to store all of the assets necessary for the Merlins homepage in the bundle cache, which does not expire, rather than in the general cache, which lives for 24 hours. Many of these changes should be applicable to other sites as well, though testing will be required

 **JIRA**: https://mobify.atlassian.net/browse/WEB-935

## Changes
- Store Google fonts, home page HTML, and preview information in the bundle cache
- Update the worker loader script in the repo to match the deployed script

## How to test-drive this PR
- Preview Merlins homepage
- Reload to ensure warm caches
- Set to offline in dev tools
- Reload and see that the home page still renders
- Delete the `progressive-web-scaffold-v0.1.2` cache in the Application tab of the dev tools
- Reload and see that the home page still renders