### PR TITLE
Port the actions and reducers to `redux-actions`

### DIFF
--- a/app/containers/app/reducer.js
+++ b/app/containers/app/reducer.js
@@ -1,4 +1,4 @@
-import {createReducer} from 'redux-act'
+import {handleActions} from 'redux-actions'
 import {Map, List} from 'immutable'
 
 import * as appActions from './actions'
@@ -11,14 +11,14 @@ const initialState = Map({
     notifications: List()
 })
 
-export default createReducer({
-    [appActions.onRouteChanged]: (state, {currentURL}) => {
+export default handleActions({
+    [appActions.onRouteChanged]: (state, {payload: {currentURL}}) => {
         return state.set(FETCH_IN_PROGRESS, true).set(CURRENT_URL, currentURL)
     },
     [appActions.onPageReceived]: (state) => {
         return state.set(FETCH_IN_PROGRESS, false)
     },
-    [appActions.addNotification]: (state, payload) => {
+    [appActions.addNotification]: (state, {payload}) => {
         return state.update('notifications', (notifications) => {
             // Don't allow duplicate notifications to be added
             const existingNotification = notifications.find((notification) => {
@@ -32,7 +32,7 @@ export default createReducer({
             }
         })
     },
-    [appActions.removeNotification]: (state, payload) => {
+    [appActions.removeNotification]: (state, {payload}) => {
         return state.update('notifications', (notifications) => {
             return notifications.filterNot((notification) => notification.id === payload)
         })

--- a/app/containers/cart/reducer.js
+++ b/app/containers/cart/reducer.js
@@ -1,4 +1,4 @@
-import {createReducer} from 'redux-act'
+import {handleActions} from 'redux-actions'
 import Immutable from 'immutable'
 import * as cartActions from './actions'
 
@@ -24,15 +24,15 @@ const initialState = Immutable.fromJS({
     ]
 })
 
-export default createReducer({
-    [cartActions.toggleEstimateShippingModal]: (state, payload) => {
+export default handleActions({
+    [cartActions.toggleEstimateShippingModal]: (state, {payload}) => {
         return state.mergeDeep({
             estimateShippingModal: {
                 isOpen: payload.isOpen
             }
         })
     },
-    [cartActions.toggleWishlistModal]: (state, payload) => {
+    [cartActions.toggleWishlistModal]: (state, {payload}) => {
         return state.mergeDeep({
             wishlistModal: {
                 isOpen: payload.isOpen

--- a/app/containers/catalog/products/reducer.js
+++ b/app/containers/catalog/products/reducer.js
@@ -1,5 +1,5 @@
 import Immutable from 'immutable'
-import {createReducer} from 'redux-act'
+import {handleActions} from 'redux-actions'
 
 import {isPageType} from '../../../utils/router-utils'
 
@@ -30,9 +30,9 @@ export const initialState = Immutable.fromJS({
     }
 })
 
-const productsReducer = createReducer({
-    [onPageReceived]: (state, action) => {
-        const {$, $response, pageComponent, url} = action
+const productsReducer = handleActions({
+    [onPageReceived]: (state, {payload}) => {
+        const {$, $response, pageComponent, url} = payload
 
         if (isPageType(pageComponent, PLP)) {
             const parsedProducts = plpParser($, $response)
@@ -53,8 +53,8 @@ const productsReducer = createReducer({
             return state
         }
     },
-    [onRouteChanged]: (state, action) => {
-        const {pageComponent, currentURL} = action
+    [onRouteChanged]: (state, {payload}) => {
+        const {pageComponent, currentURL} = payload
 
         if (isPageType(pageComponent, PDP) && !state.has(currentURL)) {
             return state.set(currentURL, initialState.get(PLACEHOLDER))

--- a/app/containers/checkout-confirmation/reducer.js
+++ b/app/containers/checkout-confirmation/reducer.js
@@ -1,4 +1,4 @@
-import {createReducer} from 'redux-act'
+import {handleActions} from 'redux-actions'
 import Immutable from 'immutable'
 import * as checkoutConfirmationActions from './actions'
 
@@ -8,8 +8,8 @@ const initialState = Immutable.fromJS({
     testText: 'Confirmation'
 })
 
-export default createReducer({
-    [checkoutConfirmationActions.receiveContents]: (state, payload) => {
+export default handleActions({
+    [checkoutConfirmationActions.receiveContents]: (state, {payload}) => {
         return state.mergeDeep(payload, {contentsLoaded: true})
     }
 }, initialState)

--- a/app/containers/checkout-payment/reducer.js
+++ b/app/containers/checkout-payment/reducer.js
@@ -1,4 +1,4 @@
-import {createReducer} from 'redux-act'
+import {handleActions} from 'redux-actions'
 import Immutable from 'immutable'
 import * as checkoutPaymentActions from './actions'
 
@@ -10,8 +10,8 @@ const initialState = Immutable.fromJS({
     }
 })
 
-export default createReducer({
-    [checkoutPaymentActions.receiveContents]: (state, payload) => {
+export default handleActions({
+    [checkoutPaymentActions.receiveContents]: (state, {payload}) => {
         return state.mergeDeep(payload, {contentsLoaded: true})
     }
 }, initialState)

--- a/app/containers/checkout-shipping/reducer.js
+++ b/app/containers/checkout-shipping/reducer.js
@@ -1,4 +1,4 @@
-import {createReducer} from 'redux-act'
+import {handleActions} from 'redux-actions'
 import Immutable from 'immutable'
 import * as checkoutShippingActions from './actions'
 
@@ -8,8 +8,8 @@ const initialState = Immutable.fromJS({
     isCompanyOrAptShown: false,
 })
 
-export default createReducer({
-    [checkoutShippingActions.receiveContents]: (state, payload) => {
+export default handleActions({
+    [checkoutShippingActions.receiveContents]: (state, {payload}) => {
         return state.mergeDeep(payload, {contentsLoaded: true})
     },
     [checkoutShippingActions.showCompanyAndApt]: (state) => {

--- a/app/containers/footer/reducer.js
+++ b/app/containers/footer/reducer.js
@@ -1,5 +1,5 @@
 import Immutable from 'immutable'
-import {createReducer} from 'redux-act'
+import {handleActions} from 'redux-actions'
 import * as appActions from '../app/actions'
 import * as footerActions from './actions'
 import * as parser from './parsers/parser'
@@ -14,18 +14,17 @@ export const initialState = Immutable.fromJS({
     signupStatus: constants.SIGNUP_NOT_ATTEMPTED
 })
 
-const footer = createReducer({
+const footer = handleActions({
 
-    [appActions.onPageReceived]: (state, action) => {
-        const {$response} = action
+    [appActions.onPageReceived]: (state, {payload: {$response}}) => {
         return state.merge(Immutable.fromJS({
             newsletter: parser.parseNewsLetter($response),
             navigation: parser.parseNavigation($response),
         }))
     },
 
-    [footerActions.newsletterSignupComplete]: (state, action) => {
-        return state.set('signupStatus', action.signupStatus)
+    [footerActions.newsletterSignupComplete]: (state, {payload}) => {
+        return state.set('signupStatus', payload.signupStatus)
     },
 
 }, initialState)

--- a/app/containers/header/reducer.js
+++ b/app/containers/header/reducer.js
@@ -1,5 +1,5 @@
 import Immutable from 'immutable'
-import {createReducer} from 'redux-act'
+import {handleActions} from 'redux-actions'
 // import * as appActions from '../app/actions'
 import * as headerActions from './actions'
 import * as cartActions from '../cart/actions'
@@ -8,13 +8,13 @@ export const initialState = Immutable.fromJS({
     isCollapsed: false
 })
 
-const header = createReducer({
+const header = handleActions({
 
-    [headerActions.toggleHeader]: (state, payload) => {
+    [headerActions.toggleHeader]: (state, {payload}) => {
         return state.set('isCollapsed', payload.isCollapsed)
     },
 
-    [cartActions.receiveCartContents]: (state, payload) => {
+    [cartActions.receiveCartContents]: (state, {payload}) => {
         return state.mergeDeep(payload)
     },
 

--- a/app/containers/home/reducer.js
+++ b/app/containers/home/reducer.js
@@ -1,4 +1,4 @@
-import {createReducer} from 'redux-act'
+import {handleActions} from 'redux-actions'
 import {fromJS} from 'immutable'
 
 import {isPageType} from '../../utils/router-utils'
@@ -13,9 +13,9 @@ const initialState = fromJS({
     banners: []
 })
 
-export default createReducer({
-    [onPageReceived]: (state, action) => {
-        const {$, $response, pageComponent} = action
+export default handleActions({
+    [onPageReceived]: (state, {payload}) => {
+        const {$, $response, pageComponent} = payload
 
         if (isPageType(pageComponent, Home)) {
             return state.mergeDeep(homeParser($, $response))

--- a/app/containers/login/reducer.js
+++ b/app/containers/login/reducer.js
@@ -1,5 +1,5 @@
 import Immutable from 'immutable'
-import {createReducer} from 'redux-act'
+import {handleActions} from 'redux-actions'
 
 import {isPageType} from '../../utils/router-utils'
 
@@ -131,9 +131,9 @@ const merge = (object1, object2) => {
     return {...object1, ...object2}
 }
 
-export default createReducer({
-    [onPageReceived]: (state, action) => {
-        const {$, $response, pageComponent, routeName} = action
+export default handleActions({
+    [onPageReceived]: (state, {payload}) => {
+        const {$, $response, pageComponent, routeName} = payload
         if (isPageType(pageComponent, Login)) {
             let newState
 
@@ -154,11 +154,11 @@ export default createReducer({
             return state
         }
     },
-    [openInfoModal]: (state, action) => {
-        return state.updateIn([formatSectionName(action.sectionName), 'infoModalOpen'], () => true)
+    [openInfoModal]: (state, {payload}) => {
+        return state.updateIn([formatSectionName(payload.sectionName), 'infoModalOpen'], () => true)
     },
-    [closeInfoModal]: (state, action) => {
-        return state.updateIn([formatSectionName(action.sectionName), 'infoModalOpen'], () => false)
+    [closeInfoModal]: (state, {payload}) => {
+        return state.updateIn([formatSectionName(payload.sectionName), 'infoModalOpen'], () => false)
     }
 
 }, initialState)

--- a/app/containers/mini-cart/reducer.js
+++ b/app/containers/mini-cart/reducer.js
@@ -1,4 +1,4 @@
-import {createReducer} from 'redux-act'
+import {handleActions} from 'redux-actions'
 import Immutable from 'immutable'
 import * as miniCartActions from './actions'
 import * as cartActions from '../cart/actions'
@@ -11,8 +11,8 @@ const initialState = Immutable.fromJS({
     }
 })
 
-export default createReducer({
-    [cartActions.receiveCartContents]: (state, payload) => {
+export default handleActions({
+    [cartActions.receiveCartContents]: (state, {payload}) => {
         return state.mergeDeep(
             {contentsLoaded: true},
             payload)

--- a/app/containers/navigation/reducer.js
+++ b/app/containers/navigation/reducer.js
@@ -1,4 +1,4 @@
-import {createReducer} from 'redux-act'
+import {handleActions} from 'redux-actions'
 import Immutable from 'immutable'
 import * as appActions from '../app/actions'
 import * as navActions from './actions'
@@ -11,8 +11,8 @@ export const initialState = Immutable.Map({
 })
 
 
-export const reducer = createReducer({
-    [appActions.onPageReceived]: (state, payload) => {
+export const reducer = handleActions({
+    [appActions.onPageReceived]: (state, {payload}) => {
         const {$, $response} = payload
         const parsed = Immutable.fromJS(parser.parseNavigation($, $response))
         return state.merge(parsed)

--- a/app/containers/pdp/reducer.js
+++ b/app/containers/pdp/reducer.js
@@ -1,5 +1,5 @@
 import Immutable from 'immutable'
-import {createReducer} from 'redux-act'
+import {handleActions} from 'redux-actions'
 
 import * as RouterUtils from '../../utils/router-utils'
 
@@ -17,9 +17,9 @@ export const initialState = Immutable.fromJS({
     quantityAdded: 0
 })
 
-const reducer = createReducer({
-    [onPageReceived]: (state, action) => {
-        const {$, $response, pageComponent, url, currentURL} = action
+const reducer = handleActions({
+    [onPageReceived]: (state, {payload}) => {
+        const {$, $response, pageComponent, url, currentURL} = payload
 
         if (RouterUtils.isPageType(pageComponent, PDP)) {
             const parsed = Immutable.fromJS(pdpParser($, $response))
@@ -41,8 +41,8 @@ const reducer = createReducer({
             return state
         }
     },
-    [onRouteChanged]: (state, action) => {
-        const {pageComponent, currentURL} = action
+    [onRouteChanged]: (state, {payload}) => {
+        const {pageComponent, currentURL} = payload
 
         if (RouterUtils.isPageType(pageComponent, PDP)) {
             return state.withMutations((s) => {
@@ -55,7 +55,7 @@ const reducer = createReducer({
             return state
         }
     },
-    [pdpActions.setItemQuantity]: (state, payload) => {
+    [pdpActions.setItemQuantity]: (state, {payload}) => {
         return RouterUtils.setInToRoutedState(state, 'itemQuantity', payload)
     },
     [pdpActions.openItemAddedModal]: (state) => {

--- a/app/containers/plp/reducer.js
+++ b/app/containers/plp/reducer.js
@@ -1,5 +1,5 @@
 import Immutable from 'immutable'
-import {createReducer} from 'redux-act'
+import {handleActions} from 'redux-actions'
 
 import {baseInitialState, isPageType, getNextSelector} from '../../utils/router-utils'
 import {onPageReceived, onRouteChanged} from '../app/actions'
@@ -17,9 +17,9 @@ export const initialState = Immutable.fromJS({
     title: ''
 })
 
-const plpReducer = createReducer({
-    [onPageReceived]: (state, action) => {
-        const {$, $response, pageComponent, url, currentURL} = action
+const plpReducer = handleActions({
+    [onPageReceived]: (state, {payload}) => {
+        const {$, $response, pageComponent, url, currentURL} = payload
 
         if (isPageType(pageComponent, PLP)) {
             const parsed = Immutable.fromJS(plpParser($, $response))
@@ -41,8 +41,8 @@ const plpReducer = createReducer({
             return state
         }
     },
-    [onRouteChanged]: (state, action) => {
-        const {pageComponent, currentURL} = action
+    [onRouteChanged]: (state, {payload}) => {
+        const {pageComponent, currentURL} = payload
 
         return isPageType(pageComponent, PLP) ? state.set(SELECTOR, getNextSelector(state, currentURL)) : state
     }

--- a/app/loader-routes.js
+++ b/app/loader-routes.js
@@ -1,4 +1,4 @@
 /* eslint-disable */
 // GENERATED FILE DO NOT EDIT
-const routes = [/^\/\/?$/,/^\/checkout\/cart\/?$/,/^\/customer\/account\/login\/?$/,/^\/customer\/account\/create\/?$/,/^\/potions\.html\/?$/,/^\/books\.html\/?$/,/^\/ingredients\.html\/?$/,/^\/supplies\.html\/?$/,/^\/new-arrivals\.html\/?$/,/^\/.*?\.html\/?$/,/^\/checkout\/shipping\/?$/,/^\/checkout\/payment\/?$/,/^\/checkout\/confirmation\/?$/]
+const routes = [/^\/\/?$/,/^\/checkout\/cart\/?$/,/^\/customer\/account\/login\/?$/,/^\/customer\/account\/create\/?$/,/^\/potions\.html\/?$/,/^\/books\.html\/?$/,/^\/ingredients\.html\/?$/,/^\/supplies\.html\/?$/,/^\/new-arrivals\.html\/?$/,/^\/charms\.html\/?$/,/^\/.*?\.html\/?$/,/^\/checkout\/shipping\/?$/,/^\/checkout\/payment\/?$/,/^\/checkout\/confirmation\/?$/]
 export default routes

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -5,7 +5,7 @@ import fromPairs from 'lodash/fromPairs'
 // simplify redux-act createAction method.
 // usage: createAction('Update Campaign', 'id', 'update')
 // instead of: createAction('Update Campaign', (id, update) => ({id, update}))
-export const createAction = (description, ...argNames) => {
+export const createLegacyAction = (description, ...argNames) => {
     let payloadReducer
 
     if (argNames.length) {
@@ -23,7 +23,7 @@ export const createAction = (description, ...argNames) => {
     return actionCreator(description, payloadReducer)
 }
 
-export const createRAAction = (description, ...argNames) => {
+export const createAction = (description, ...argNames) => {
     return reduxAction(
         description,
         argNames.length ?

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -1,5 +1,5 @@
 import {createAction as createReduxAction} from 'redux-actions'
-import fromPairs from 'lodash/fromPairs'
+import fromPairs from 'lodash.frompairs'
 
 // simplify redux-actions createAction method.
 // usage: createAction('Update Campaign', 'id', 'update')

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -1,30 +1,11 @@
-import {createAction as actionCreator} from 'redux-act'
-import {createAction as reduxAction} from 'redux-actions'
+import {createAction as createReduxAction} from 'redux-actions'
 import fromPairs from 'lodash/fromPairs'
 
-// simplify redux-act createAction method.
+// simplify redux-actions createAction method.
 // usage: createAction('Update Campaign', 'id', 'update')
 // instead of: createAction('Update Campaign', (id, update) => ({id, update}))
-export const createLegacyAction = (description, ...argNames) => {
-    let payloadReducer
-
-    if (argNames.length) {
-        payloadReducer = (...args) => {
-            const payload = {}
-
-            argNames.forEach((arg, index) => {
-                payload[arg] = args[index]
-            })
-
-            return payload
-        }
-    }
-
-    return actionCreator(description, payloadReducer)
-}
-
 export const createAction = (description, ...argNames) => {
-    return reduxAction(
+    return createReduxAction(
         description,
         argNames.length ?
             (...args) => fromPairs(argNames.map((arg, idx) => [arg, args[idx]]))

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -1,4 +1,6 @@
 import {createAction as actionCreator} from 'redux-act'
+import {createAction as reduxAction} from 'redux-actions'
+import fromPairs from 'lodash/fromPairs'
 
 // simplify redux-act createAction method.
 // usage: createAction('Update Campaign', 'id', 'update')
@@ -19,6 +21,15 @@ export const createAction = (description, ...argNames) => {
     }
 
     return actionCreator(description, payloadReducer)
+}
+
+export const createRAAction = (description, ...argNames) => {
+    return reduxAction(
+        description,
+        argNames.length ?
+            (...args) => fromPairs(argNames.map((arg, idx) => [arg, args[idx]]))
+            : null
+    )
 }
 
 export const makeRequest = (url, options) => {

--- a/app/utils/utils.test.js
+++ b/app/utils/utils.test.js
@@ -1,0 +1,27 @@
+import {createAction} from './utils'
+
+test('createAction creates a multi-argument action creator if names are passed', () => {
+    const actionCreator = createAction('Test Action', 'a', 'b', 'c')
+    expect(typeof actionCreator).toBe('function')
+
+    const action = actionCreator(1, 2, 3)
+    expect(action).toEqual({
+        type: 'Test Action',
+        payload: {
+            a: 1,
+            b: 2,
+            c: 3
+        }
+    })
+})
+
+test('createAction creates a single-argument action creator if no names are passed', () => {
+    const actionCreator = createAction('Complete Test')
+    expect(typeof actionCreator).toBe('function')
+
+    const action = actionCreator('payload', 'ignored')
+    expect(action).toEqual({
+        type: 'Complete Test',
+        payload: 'payload'
+    })
+})

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "react-redux": "4.4.5",
     "react-router": "2.7.0",
     "redux": "3.6.0",
-    "redux-act": "1.1.0",
     "redux-actions": "1.2.0",
     "redux-thunk": "2.1.0",
     "sw-toolbox": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-router": "2.7.0",
     "redux": "3.6.0",
     "redux-act": "1.1.0",
+    "redux-actions": "1.2.0",
     "redux-thunk": "2.1.0",
     "sw-toolbox": "3.4.0",
     "whatwg-fetch": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-runtime": "6.11.6",
     "es6-promise": "4.0.5",
     "immutable": "3.8.1",
+    "lodash.frompairs": "4.0.1",
     "react": "15.4.1",
     "react-dom": "15.4.1",
     "react-redux": "4.4.5",


### PR DESCRIPTION
The `redux-act` library is very helpful but is not very widely used. A similar library made by people close to the core Redux team is `redux-actions`.  This PR ports the scaffold from `redux-act` to `redux-actions`. 

A benefit to `redux-actions` is that its actions and reducers support a separate path for errors in each action, triggered by passing an `Error` object as the action parameter, which will cut down on the number of distinct actions in our application. It is also 13% smaller minified and gzipped. 

The main user-visible changes are in the reducer. The `handleActions` function takes the place of the `createReducer` function, and the individual action handler functions are now passed the full action object rather than just the payload. The utility function `createAction` has been updated compatibly to use `redux-action` rather than `redux-act`.

NOTE: This breaks compatibility with the container generator, prior to a follow-up SDK PR.

 **JIRA**: N/A (preparatory for middleware work)

## Changes
- Replace `redux-actions` with `redux-act`

## How to test-drive this PR
- Run the tests
- Preview and see that the site still functions as before.
