### PR TITLE
Selectorize store access

### DIFF
--- a/app/containers/app/actions.js
+++ b/app/containers/app/actions.js
@@ -1,6 +1,6 @@
 import {jqueryResponse} from 'progressive-web-sdk/dist/jquery-response'
 import * as utils from '../../utils/utils'
-import {CURRENT_URL} from './constants'
+import * as selectors from './selectors'
 
 export const addNotification = utils.createAction('Add Notification')
 export const removeNotification = utils.createAction('Remove Notification')
@@ -41,7 +41,7 @@ export const fetchPage = (url, pageComponent, routeName) => {
             .then(jqueryResponse)
             .then((res) => {
                 const [$, $response] = res
-                const currentURL = getState().app.get(CURRENT_URL)
+                const currentURL = selectors.getCurrentUrl(getState())
                 dispatch(onPageReceived($, $response, pageComponent, url, currentURL, routeName))
             })
             .catch((error) => { console.info(error.message) })

--- a/app/containers/app/actions.test.js
+++ b/app/containers/app/actions.test.js
@@ -30,7 +30,7 @@ test('fetchPage fetches the given page', () => {
     expect(typeof thunk).toBe('function')
 
     const fakeDispatch = jest.fn()
-    const getState = () => ({app: Immutable.fromJS({[CURRENT_URL]: 'test'})})
+    const getState = () => ({ui: {app: Immutable.fromJS({[CURRENT_URL]: 'test'})}})
 
     return thunk(fakeDispatch, getState)
         .then(() => {
@@ -53,7 +53,7 @@ test('fetchPage does not throw on error', () => {
     expect(typeof thunk).toBe('function')
 
     const fakeDispatch = jest.fn()
-    const getState = () => ({app: Immutable.fromJS({[CURRENT_URL]: 'test'})})
+    const getState = () => ({ui: {app: Immutable.fromJS({[CURRENT_URL]: 'test'})}})
 
     return thunk(fakeDispatch, getState)
         .catch(() => expect('The catch clause was called').toEqual('catch was not called'))

--- a/app/containers/app/container.js
+++ b/app/containers/app/container.js
@@ -1,5 +1,7 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
+import {createStructuredSelector} from 'reselect'
+
 import {hidePreloader} from 'progressive-web-sdk/dist/preloader'
 import {IconSprite} from 'progressive-web-sdk/dist/components/icon'
 import SkipLinks from 'progressive-web-sdk/dist/components/skip-links'
@@ -11,6 +13,7 @@ import * as navActions from '../../containers/navigation/actions'
 import * as miniCartActions from '../../containers/mini-cart/actions'
 import sprite from '../../static/svg/sprite-dist/sprite.svg'
 import * as appActions from '../app/actions'
+import * as selectors from './selectors'
 
 import NotificationManager from '../../components/notification-manager'
 
@@ -108,13 +111,11 @@ App.propTypes = {
     requestOpenMiniCart: PropTypes.func,
 }
 
-const mapStateToProps = (state) => {
-    return {
-        app: state.app,
-    }
-}
+const mapStateToProps = createStructuredSelector({
+    app: selectors.getApp
+})
 
-const mapDispatchToProps = (dispatch, props) => {
+const mapDispatchToProps = (dispatch) => {
     return {
         openNavigation: () => dispatch(navActions.openNavigation()),
         requestOpenMiniCart: () => dispatch(miniCartActions.requestOpenMiniCart()),

--- a/app/containers/app/selectors.js
+++ b/app/containers/app/selectors.js
@@ -1,0 +1,1 @@
+export const getApp = ({app}) => app

--- a/app/containers/app/selectors.js
+++ b/app/containers/app/selectors.js
@@ -1,6 +1,11 @@
-export const getApp = ({app}) => app
 import {createSelector} from 'reselect'
+import * as globalSelectors from '../../store/selectors'
 import {CURRENT_URL} from './constants'
+
+export const getApp = createSelector(
+    globalSelectors.getUi,
+    ({app}) => app
+)
 
 export const getCurrentUrl = createSelector(
     getApp,

--- a/app/containers/app/selectors.js
+++ b/app/containers/app/selectors.js
@@ -1,1 +1,8 @@
 export const getApp = ({app}) => app
+import {createSelector} from 'reselect'
+import {CURRENT_URL} from './constants'
+
+export const getCurrentUrl = createSelector(
+    getApp,
+    (app) => app.get(CURRENT_URL)
+)

--- a/app/containers/cart/container.js
+++ b/app/containers/cart/container.js
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import Immutable from 'immutable'
+import {createStructuredSelector} from 'reselect'
 import {getAssetUrl} from 'progressive-web-sdk/dist/asset-utils'
 import classNames from 'classnames'
 
@@ -10,6 +11,7 @@ import {Icon} from 'progressive-web-sdk/dist/components/icon'
 import Image from 'progressive-web-sdk/dist/components/image'
 
 import * as actions from './actions'
+import * as selectors from './selectors'
 import CartProductList from './partials/cart-product-list'
 import CartSummary from './partials/cart-summary'
 import CartEstimateShippingModal from './partials/cart-estimate-shipping'
@@ -160,12 +162,10 @@ Cart.propTypes = {
     toggleWishlistModal: PropTypes.func,
 }
 
-const mapStateToProps = (state) => {
-    return {
-        cart: state.cart,
-        miniCart: state.miniCart,
-    }
-}
+const mapStateToProps = createStructuredSelector({
+    cart: selectors.getCart,
+    miniCart: selectors.getMiniCart
+})
 
 const mapDispatchToProps = {
     toggleEstimateShippingModal: actions.toggleEstimateShippingModal,

--- a/app/containers/cart/selectors.js
+++ b/app/containers/cart/selectors.js
@@ -1,0 +1,2 @@
+export const getCart = ({cart}) => cart
+export const getMiniCart = ({miniCart}) => miniCart

--- a/app/containers/cart/selectors.js
+++ b/app/containers/cart/selectors.js
@@ -1,2 +1,12 @@
-export const getCart = ({cart}) => cart
-export const getMiniCart = ({miniCart}) => miniCart
+import {createSelector} from 'reselect'
+import * as globalSelectors from '../../store/selectors'
+
+export const getCart = createSelector(
+    globalSelectors.getUi,
+    ({cart}) => cart
+)
+
+export const getMiniCart = createSelector(
+    globalSelectors.getUi,
+    ({miniCart}) => miniCart
+)

--- a/app/containers/footer/container.js
+++ b/app/containers/footer/container.js
@@ -1,7 +1,9 @@
 import React, {PropTypes} from 'react'
 import Immutable from 'immutable'
 import {connect} from 'react-redux'
+import {createStructuredSelector} from 'reselect'
 import * as actions from './actions'
+import * as selectors from './selectors'
 
 import FooterNewsletterSubscription from './partials/footer-newsletter-subscription'
 import FooterSocialIcons from './partials/footer-social-icons'
@@ -59,11 +61,9 @@ Footer.propTypes = {
 }
 
 
-const mapStateToProps = (state) => {
-    return {
-        footer: state.footer,
-    }
-}
+const mapStateToProps = createStructuredSelector({
+    footer: selectors.getFooter
+})
 
 const mapDispatchToProps = {
     submitNewsletter: actions.signUpToNewsletter

--- a/app/containers/footer/selectors.js
+++ b/app/containers/footer/selectors.js
@@ -1,0 +1,1 @@
+export const getFooter = ({footer}) => footer

--- a/app/containers/footer/selectors.js
+++ b/app/containers/footer/selectors.js
@@ -1,1 +1,6 @@
-export const getFooter = ({footer}) => footer
+import {createSelector} from 'reselect'
+import * as globalSelectors from '../../store/selectors'
+export const getFooter = createSelector(
+    globalSelectors.getUi,
+    ({footer}) => footer
+)

--- a/app/containers/header/container.js
+++ b/app/containers/header/container.js
@@ -1,8 +1,10 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
+import {createStructuredSelector} from 'reselect'
 import throttle from 'lodash.throttle'
 import classnames from 'classnames'
 import * as headerActions from './actions'
+import * as selectors from './selectors'
 
 import Button from 'progressive-web-sdk/dist/components/button'
 import IconLabel from 'progressive-web-sdk/dist/components/icon-label'
@@ -118,11 +120,9 @@ Header.propTypes = {
     onMiniCartClick: PropTypes.func,
 }
 
-const mapStateToProps = (state, props) => {
-    return {
-        header: state.header
-    }
-}
+const mapStateToProps = createStructuredSelector({
+    header: selectors.getHeader
+})
 
 const mapDispatchToProps = {
     toggleHeader: headerActions.toggleHeader

--- a/app/containers/header/selectors.js
+++ b/app/containers/header/selectors.js
@@ -1,1 +1,6 @@
-export const getHeader = ({header}) => header
+import {createSelector} from 'reselect'
+import * as globalSelectors from '../../store/selectors'
+export const getHeader = createSelector(
+    globalSelectors.getUi,
+    ({header}) => header
+)

--- a/app/containers/header/selectors.js
+++ b/app/containers/header/selectors.js
@@ -1,0 +1,1 @@
+export const getHeader = ({header}) => header

--- a/app/containers/home/container.js
+++ b/app/containers/home/container.js
@@ -1,17 +1,19 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import Immutable from 'immutable'
+import {createStructuredSelector} from 'reselect'
 
+import * as selectors from './selectors'
 import HomeCarousel from './partials/home-carousel'
 import HomeCategories from './partials/home-categories'
 
 class Home extends React.Component {
     shouldComponentUpdate(nextProps) {
-        return !Immutable.is(this.props.homeState, nextProps.homeState)
+        return !Immutable.is(this.props.home, nextProps.home)
     }
 
     render() {
-        const {banners, categories} = this.props
+        const {banners, categories} = this.props.home.toJS()
 
         return (
             <div className="t-home__container">
@@ -23,20 +25,12 @@ class Home extends React.Component {
 }
 
 Home.propTypes = {
-    banners: PropTypes.oneOfType([
-        PropTypes.bool,
-        PropTypes.array
-    ]).isRequired,
-    categories: PropTypes.array.isRequired,
-    homeState: PropTypes.object.isRequired
+    home: PropTypes.object.isRequired
 }
 
-const mapStateToProps = (state) => {
-    return {
-        homeState: state.home,
-        ...state.home.toJS()
-    }
-}
+const mapStateToProps = createStructuredSelector({
+    home: selectors.getHome
+})
 
 export default connect(
     mapStateToProps

--- a/app/containers/home/selectors.js
+++ b/app/containers/home/selectors.js
@@ -1,1 +1,7 @@
-export const getHome = ({home}) => home
+import {createSelector} from 'reselect'
+import * as globalSelectors from '../../store/selectors'
+
+export const getHome = createSelector(
+    globalSelectors.getUi,
+    ({home}) => home
+)

--- a/app/containers/home/selectors.js
+++ b/app/containers/home/selectors.js
@@ -1,0 +1,1 @@
+export const getHome = ({home}) => home

--- a/app/containers/login/container.js
+++ b/app/containers/login/container.js
@@ -10,6 +10,7 @@ import SkeletonText from 'progressive-web-sdk/dist/components/skeleton-text'
 import {Tabs, TabsPanel} from 'progressive-web-sdk/dist/components/tabs'
 
 import * as actions from './actions'
+import * as selectors from './selectors'
 
 class Login extends React.Component {
 
@@ -148,7 +149,7 @@ class Login extends React.Component {
 
 const mapStateToProps = (state, props) => {
     return {
-        ...state.login.toJS()
+        ...selectors.getLogin(state).toJS()
     }
 }
 

--- a/app/containers/login/selectors.js
+++ b/app/containers/login/selectors.js
@@ -1,1 +1,7 @@
-export const getLogin = ({login}) => login
+import {createSelector} from 'reselect'
+import * as globalSelectors from '../../store/selectors'
+
+export const getLogin = createSelector(
+    globalSelectors.getUi,
+    ({login}) => login
+)

--- a/app/containers/login/selectors.js
+++ b/app/containers/login/selectors.js
@@ -1,0 +1,1 @@
+export const getLogin = ({login}) => login

--- a/app/containers/mini-cart/container.js
+++ b/app/containers/mini-cart/container.js
@@ -2,6 +2,7 @@ import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import Immutable from 'immutable'
 import classNames from 'classnames'
+import {createStructuredSelector} from 'reselect'
 import {getAssetUrl} from 'progressive-web-sdk/dist/asset-utils'
 
 import Button from 'progressive-web-sdk/dist/components/button'
@@ -10,6 +11,7 @@ import Sheet from 'progressive-web-sdk/dist/components/sheet'
 import List from 'progressive-web-sdk/dist/components/list'
 import Image from 'progressive-web-sdk/dist/components/image'
 import ProductItem from '../../components/product-item'
+import * as selectors from './selectors'
 import * as miniCartActions from './actions'
 import * as cartActions from '../cart/actions'
 import {HeaderBar, HeaderBarActions, HeaderBarTitle} from 'progressive-web-sdk/dist/components/header-bar'
@@ -136,7 +138,9 @@ MiniCart.propTypes = {
     fetchContents: PropTypes.func,
 }
 
-const mapStateToProps = ({miniCart}) => ({miniCart})
+const mapStateToProps = createStructuredSelector({
+    miniCart: selectors.getMiniCart
+})
 
 const mapDispatchToProps = {
     fetchContents: cartActions.getCart,

--- a/app/containers/mini-cart/selectors.js
+++ b/app/containers/mini-cart/selectors.js
@@ -1,0 +1,1 @@
+export const getMiniCart = ({miniCart}) => miniCart

--- a/app/containers/mini-cart/selectors.js
+++ b/app/containers/mini-cart/selectors.js
@@ -1,1 +1,7 @@
-export const getMiniCart = ({miniCart}) => miniCart
+import {createSelector} from 'reselect'
+import * as globalSelectors from '../../store/selectors'
+
+export const getMiniCart = createSelector(
+    globalSelectors.getUi,
+    ({miniCart}) => miniCart
+)

--- a/app/containers/navigation/container.js
+++ b/app/containers/navigation/container.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import {connect} from 'react-redux'
+import {createStructuredSelector} from 'reselect'
 import Nav from 'progressive-web-sdk/dist/components/nav'
 import NavMenu from 'progressive-web-sdk/dist/components/nav-menu'
 import NavItem from 'progressive-web-sdk/dist/components/nav-item'
@@ -7,6 +8,7 @@ import Sheet from 'progressive-web-sdk/dist/components/sheet'
 import * as navActions from './actions'
 import IconLabelButton from '../../components/icon-label-button'
 import * as merlinsNavItem from '../../components/nav-item'
+import * as selectors from './selectors'
 import {HeaderBar, HeaderBarActions, HeaderBarTitle} from 'progressive-web-sdk/dist/components/header-bar'
 import {withRouter} from 'react-router'
 
@@ -79,12 +81,9 @@ Navigation.propTypes = {
 }
 
 
-const mapStateToProps = (state) => {
-    return {
-        navigation: state.navigation,
-    }
-}
-
+const mapStateToProps = createStructuredSelector({
+    navigation: selectors.getNavigation
+})
 
 export default connect(
     mapStateToProps,

--- a/app/containers/navigation/selectors.js
+++ b/app/containers/navigation/selectors.js
@@ -1,0 +1,1 @@
+export const getNavigation = ({navigation}) => navigation

--- a/app/containers/navigation/selectors.js
+++ b/app/containers/navigation/selectors.js
@@ -1,1 +1,7 @@
-export const getNavigation = ({navigation}) => navigation
+import {createSelector} from 'reselect'
+import * as globalSelectors from '../../store/selectors'
+
+export const getNavigation = createSelector(
+    globalSelectors.getUi,
+    ({navigation}) => navigation
+)

--- a/app/containers/pdp/container.js
+++ b/app/containers/pdp/container.js
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import Immutable from 'immutable'
+import {createSelector} from 'reselect'
 
 import PDPHeading from './partials/pdp-heading'
 import PDPCarousel from './partials/pdp-carousel'
@@ -9,6 +10,7 @@ import PDPAddToCart from './partials/pdp-add-to-cart'
 import PDPItemAddedModal from './partials/pdp-item-added-modal'
 import {stripEvent} from '../../utils/utils'
 import * as pdpActions from './actions'
+import * as selectors from './selectors'
 import {getSelectorFromState} from '../../utils/router-utils'
 
 class PDP extends React.Component {
@@ -92,13 +94,17 @@ PDP.propTypes = {
     setQuantity: PropTypes.func.isRequired,
 }
 
-export const mapStateToProps = ({catalog, pdp}) => {
-    const selector = getSelectorFromState(pdp)
-    return {
-        catalogProduct: catalog.products.get(selector),
-        pdp: pdp.get(selector)
+export const mapStateToProps = createSelector(
+    selectors.getCatalog,
+    selectors.getPdp,
+    (catalog, pdp) => {
+        const selector = getSelectorFromState(pdp)
+        return {
+            catalogProduct: catalog.products.get(selector),
+            pdp: pdp.get(selector)
+        }
     }
-}
+)
 
 const mapDispatchToProps = {
     setQuantity: pdpActions.setItemQuantity,

--- a/app/containers/pdp/selectors.js
+++ b/app/containers/pdp/selectors.js
@@ -1,0 +1,2 @@
+export const getPdp = ({pdp}) => pdp
+export const getCatalog = ({catalog}) => catalog

--- a/app/containers/pdp/selectors.js
+++ b/app/containers/pdp/selectors.js
@@ -5,7 +5,4 @@ export const getPdp = createSelector(
     globalSelectors.getUi,
     ({pdp}) => pdp
 )
-export const getCatalog = createSelector(
-    globalSelectors.getUi,
-    ({catalog}) => catalog
-)
+export const getCatalog = globalSelectors.getCatalog

--- a/app/containers/pdp/selectors.js
+++ b/app/containers/pdp/selectors.js
@@ -1,2 +1,11 @@
-export const getPdp = ({pdp}) => pdp
-export const getCatalog = ({catalog}) => catalog
+import {createSelector} from 'reselect'
+import * as globalSelectors from '../../store/selectors'
+
+export const getPdp = createSelector(
+    globalSelectors.getUi,
+    ({pdp}) => pdp
+)
+export const getCatalog = createSelector(
+    globalSelectors.getUi,
+    ({catalog}) => catalog
+)

--- a/app/containers/plp/container.js
+++ b/app/containers/plp/container.js
@@ -2,7 +2,9 @@ import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import Immutable from 'immutable'
 import {getAssetUrl} from 'progressive-web-sdk/dist/asset-utils'
+import {createSelector} from 'reselect'
 
+import * as selectors from './selectors'
 import Image from 'progressive-web-sdk/dist/components/image'
 import Link from 'progressive-web-sdk/dist/components/link'
 import List from 'progressive-web-sdk/dist/components/list'
@@ -106,19 +108,23 @@ PLP.propTypes = {
     products: PropTypes.array.isRequired
 }
 
-const mapStateToProps = ({catalog, plp}) => {
-    const selector = getSelectorFromState(plp)
-    const routedPlp = plp.get(selector)
-    const productUrls = routedPlp.get('productUrls').toJS()
-    const catalogProducts = catalog.products
-    const products = productUrls.map((url) => {
-        return catalogProducts.get(url).toJS()
-    })
-    return {
-        products,
-        plp: routedPlp
+const mapStateToProps = createSelector(
+    selectors.getCatalog,
+    selectors.getPlp,
+    (catalog, plp) => {
+        const selector = getSelectorFromState(plp)
+        const routedPlp = plp.get(selector)
+        const productUrls = routedPlp.get('productUrls').toJS()
+        const catalogProducts = catalog.products
+        const products = productUrls.map((url) => {
+            return catalogProducts.get(url).toJS()
+        })
+        return {
+            products,
+            plp: routedPlp
+        }
     }
-}
+)
 
 export default connect(
     mapStateToProps

--- a/app/containers/plp/selectors.js
+++ b/app/containers/plp/selectors.js
@@ -1,0 +1,2 @@
+export const getCatalog = ({catalog}) => catalog
+export const getPlp = ({plp}) => plp

--- a/app/containers/plp/selectors.js
+++ b/app/containers/plp/selectors.js
@@ -1,10 +1,7 @@
 import {createSelector} from 'reselect'
 import * as globalSelectors from '../../store/selectors'
 
-export const getCatalog = createSelector(
-    globalSelectors.getUi,
-    ({catalog}) => catalog
-)
+export const getCatalog = globalSelectors.getCatalog
 
 export const getPlp = createSelector(
     globalSelectors.getUi,

--- a/app/containers/plp/selectors.js
+++ b/app/containers/plp/selectors.js
@@ -1,2 +1,12 @@
-export const getCatalog = ({catalog}) => catalog
-export const getPlp = ({plp}) => plp
+import {createSelector} from 'reselect'
+import * as globalSelectors from '../../store/selectors'
+
+export const getCatalog = createSelector(
+    globalSelectors.getUi,
+    ({catalog}) => catalog
+)
+
+export const getPlp = createSelector(
+    globalSelectors.getUi,
+    ({plp}) => plp
+)

--- a/app/containers/reducers.js
+++ b/app/containers/reducers.js
@@ -16,7 +16,7 @@ import miniCart from './mini-cart/reducer'
 import navigation from './navigation/reducer'
 import pdp from './pdp/reducer'
 import plp from './plp/reducer'
-import {reducer as formReducer} from 'redux-form'
+// import {reducer as formReducer} from 'redux-form'
 
 
 const rootReducer = combineReducers({
@@ -34,7 +34,7 @@ const rootReducer = combineReducers({
     navigation,
     pdp,
     plp,
-    form: formReducer,
+    // form: formReducer,
 
 })
 

--- a/app/containers/reducers.js
+++ b/app/containers/reducers.js
@@ -3,7 +3,7 @@
 import {combineReducers} from 'redux'
 
 import app from './app/reducer'
-import catalog from './catalog/reducer'
+// import catalog from './catalog/reducer'
 import cart from './cart/reducer'
 import checkoutConfirmation from './checkout-confirmation/reducer'
 import checkoutPayment from './checkout-payment/reducer'
@@ -21,7 +21,7 @@ import plp from './plp/reducer'
 
 const rootReducer = combineReducers({
     app,
-    catalog,
+    // catalog,
     cart,
     checkoutConfirmation,
     checkoutPayment,

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -1,9 +1,15 @@
-import {createStore, compose, applyMiddleware} from 'redux'
+import {createStore, combineReducers, compose, applyMiddleware} from 'redux'
 import thunk from 'redux-thunk'
 
 import rootReducer from '../containers/reducers'
+import {reducer as formReducer} from 'redux-form'
 
 const noop = (f) => f
+
+const reducer = combineReducers({
+    ui: rootReducer,
+    form: formReducer
+})
 
 const configureStore = (initialState) => {
     const middlewares = [
@@ -11,7 +17,7 @@ const configureStore = (initialState) => {
     ]
 
     const store = createStore(
-        rootReducer,
+        reducer,
         initialState,
         compose(
             applyMiddleware(...middlewares),

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -2,11 +2,13 @@ import {createStore, combineReducers, compose, applyMiddleware} from 'redux'
 import thunk from 'redux-thunk'
 
 import rootReducer from '../containers/reducers'
+import catalogReducer from '../containers/catalog/reducer'
 import {reducer as formReducer} from 'redux-form'
 
 const noop = (f) => f
 
 const reducer = combineReducers({
+    catalog: catalogReducer,
     ui: rootReducer,
     form: formReducer
 })

--- a/app/store/selectors.js
+++ b/app/store/selectors.js
@@ -1,0 +1,2 @@
+export const getUi = ({ui}) => ui
+export const getCatalog = ({catalog}) => catalog

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "redux": "3.6.0",
     "redux-actions": "1.2.0",
     "redux-thunk": "2.1.0",
+    "reselect": "2.5.4",
     "sw-toolbox": "3.4.0",
     "whatwg-fetch": "1.0.0"
   },


### PR DESCRIPTION
This PR uses `reselect` to selectorize all access to the Redux state, and uses the latitude that grants to refactor the store a little. The data access patterns remain the same, including the passing of Immutable objects to React components.

 **JIRA**: (link to JIRA ticket)
 **Linked PRs**: (links to corresponding PRs, optional)

## Changes
- (change1)

## How to test-drive this PR
- (necessary config changes)
- (necessary corresponding PRs)
- (how to access the new / changed functionality -- fixtures, URLs)
