### PR TITLE
Make footer sticky across site

### DIFF
--- a/app/containers/app/_app.scss
+++ b/app/containers/app/_app.scss
@@ -9,3 +9,14 @@
     // wrapper element.
     display: block !important; // 1
 }
+
+
+// Wrapper
+// ---
+//
+// 1. This, combined with the flexbox classes in the template, create a sticky
+//    footer effect!
+
+.t-app__wrapper {
+    min-height: 100vh; // 1
+}

--- a/app/containers/app/container.js
+++ b/app/containers/app/container.js
@@ -31,9 +31,15 @@ class App extends React.Component {
     }
 
     render() {
-        const {requestOpenMiniCart, openNavigation, history, children, app, notificationActions} = this.props
+        const {
+            app,
+            children,
+            history,
+            notificationActions,
+            openNavigation,
+            requestOpenMiniCart,
+        } = this.props
         const currentTemplateProps = children.props
-        const currentTemplate = `app--${currentTemplateProps.route.routeName}`
         const CurrentHeader = currentTemplateProps.route.Header || Header
         const CurrentFooter = currentTemplateProps.route.Footer || Footer
         const {notifications} = app.toJS()
@@ -51,26 +57,37 @@ class App extends React.Component {
         ]
 
         return (
-            <div id="app" className="t-app" style={{display: 'none'}}>
+            <div
+                id="app"
+                className={`t-app app--${currentTemplateProps.route.routeName}`}
+                style={{display: 'none'}}
+            >
                 <IconSprite sprite={sprite} />
                 <SkipLinks items={skipLinksItems} />
 
-                <div id="app-wrap" className={currentTemplate}>
-                    <div id="app-header" role="banner">
-                        <CurrentHeader onMenuClick={openNavigation} onMiniCartClick={requestOpenMiniCart} />
+                <div id="app-wrap" className="t-app__wrapper u-flexbox u-direction-column">
+                    <div id="app-header" className="t-app__header u-flex-none" role="banner">
+                        <CurrentHeader
+                            onMenuClick={openNavigation}
+                            onMiniCartClick={requestOpenMiniCart}
+                        />
+
                         {notifications &&
-                            <NotificationManager notifications={notifications} actions={notificationActions} />
+                            <NotificationManager
+                                notifications={notifications}
+                                actions={notificationActions}
+                            />
                         }
 
                         <Navigation history={history} />
                         <MiniCart />
                     </div>
 
-                    <main id="app-main" role="main">
+                    <main id="app-main" className="t-app__main u-flex" role="main">
                         {this.props.children}
                     </main>
 
-                    <div id="app-footer">
+                    <div id="app-footer" className="t-app__footer u-flex-none">
                         <CurrentFooter />
                     </div>
                 </div>

--- a/app/containers/app/container.js
+++ b/app/containers/app/container.js
@@ -59,7 +59,7 @@ class App extends React.Component {
         return (
             <div
                 id="app"
-                className={`t-app app--${currentTemplateProps.route.routeName}`}
+                className={`t-app t-app--${currentTemplateProps.route.routeName}`}
                 style={{display: 'none'}}
             >
                 <IconSprite sprite={sprite} />

--- a/app/containers/app/container.js
+++ b/app/containers/app/container.js
@@ -66,7 +66,7 @@ class App extends React.Component {
                 <SkipLinks items={skipLinksItems} />
 
                 <div id="app-wrap" className="t-app__wrapper u-flexbox u-direction-column">
-                    <div id="app-header" className="t-app__header u-flex-none" role="banner">
+                    <div id="app-header" className="u-flex-none" role="banner">
                         <CurrentHeader
                             onMenuClick={openNavigation}
                             onMiniCartClick={requestOpenMiniCart}
@@ -83,11 +83,11 @@ class App extends React.Component {
                         <MiniCart />
                     </div>
 
-                    <main id="app-main" className="t-app__main u-flex" role="main">
+                    <main id="app-main" className="u-flex" role="main">
                         {this.props.children}
                     </main>
 
-                    <div id="app-footer" className="t-app__footer u-flex-none">
+                    <div id="app-footer" className="u-flex-none">
                         <CurrentFooter />
                     </div>
                 </div>


### PR DESCRIPTION
Add sticky footer effect to Merlin's Potions

## Changes
- Apply "sticky footer" effect to site
- Moved the `app--${currentTemplateProps.route.routeName}` class to live on the same element as `t-app`

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Test both tall pages (just about any existing page) and a short page (i.e. the [Confirmation page](https://www.merlinspotions.com/checkout/confirmation/) either before it gets merged, or on desktop after it gets merged.
- Ensure footer is sticky, and doesn't have any negative side effects on the functionality of the site (i.e. messing up how the site scrolls)
