### PR TITLE
Remove Immutable from React components

### DIFF
--- a/app/containers/app/container.js
+++ b/app/containers/app/container.js
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import {createStructuredSelector} from 'reselect'
+import {selectorToJS} from '../../utils/selector-utils'
 
 import {hidePreloader} from 'progressive-web-sdk/dist/preloader'
 import {IconSprite} from 'progressive-web-sdk/dist/components/icon'
@@ -45,7 +46,7 @@ class App extends React.Component {
         const currentTemplateProps = children.props
         const CurrentHeader = currentTemplateProps.route.Header || Header
         const CurrentFooter = currentTemplateProps.route.Footer || Footer
-        const {notifications} = app.toJS()
+        const {notifications} = app
 
         const skipLinksItems = [
             // Customize your list of SkipLinks here. These are necessary to
@@ -112,7 +113,7 @@ App.propTypes = {
 }
 
 const mapStateToProps = createStructuredSelector({
-    app: selectors.getApp
+    app: selectorToJS(selectors.getApp)
 })
 
 const mapDispatchToProps = (dispatch) => {

--- a/app/containers/cart/container.js
+++ b/app/containers/cart/container.js
@@ -1,6 +1,5 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
-import Immutable from 'immutable'
 import {createStructuredSelector} from 'reselect'
 import {selectorToJS} from '../../utils/selector-utils'
 import {getAssetUrl} from 'progressive-web-sdk/dist/asset-utils'

--- a/app/containers/cart/container.js
+++ b/app/containers/cart/container.js
@@ -2,6 +2,7 @@ import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import Immutable from 'immutable'
 import {createStructuredSelector} from 'reselect'
+import {selectorToJS} from '../../utils/selector-utils'
 import {getAssetUrl} from 'progressive-web-sdk/dist/asset-utils'
 import classNames from 'classnames'
 
@@ -25,12 +26,6 @@ class Cart extends React.Component {
         this.closeEstimateShippingModal = this.closeEstimateShippingModal.bind(this)
         this.openWishlistModal = this.openWishlistModal.bind(this)
         this.closeWishlistModal = this.closeWishlistModal.bind(this)
-    }
-
-    shouldComponentUpdate(newProps) {
-        const miniCartChanged = !Immutable.is(newProps.miniCart, this.props.miniCart)
-        const cartChanged = !Immutable.is(newProps.cart, this.props.cart)
-        return miniCartChanged || cartChanged
     }
 
     openEstimateShippingModal() {
@@ -116,14 +111,13 @@ class Cart extends React.Component {
     }
 
     render() {
-        const cart = this.props.miniCart.get('cart').toJS()
-        const contentsLoaded = this.props.miniCart.get('contentsLoaded')
+        const {cart, contentsLoaded} = this.props.miniCart
         const {
             estimateShippingModal,
             wishlistModal,
             countries,
             stateProvinces
-        } = this.props.cart.toJS()
+        } = this.props.cart
         const isCartEmptyAndLoaded = cart.items.length === 0 && contentsLoaded
         const templateClassnames = classNames('t-cart u-bg-color-neutral-20', {
             't--loaded': contentsLoaded
@@ -163,8 +157,8 @@ Cart.propTypes = {
 }
 
 const mapStateToProps = createStructuredSelector({
-    cart: selectors.getCart,
-    miniCart: selectors.getMiniCart
+    cart: selectorToJS(selectors.getCart),
+    miniCart: selectorToJS(selectors.getMiniCart)
 })
 
 const mapDispatchToProps = {

--- a/app/containers/footer/container.js
+++ b/app/containers/footer/container.js
@@ -2,6 +2,8 @@ import React, {PropTypes} from 'react'
 import Immutable from 'immutable'
 import {connect} from 'react-redux'
 import {createStructuredSelector} from 'reselect'
+import {selectorToJS} from '../../utils/selector-utils'
+
 import * as actions from './actions'
 import * as selectors from './selectors'
 
@@ -24,20 +26,13 @@ class Footer extends React.Component {
     }
 
     onSubmitNewsletter(data) {
-        const method = this.props.footer.getIn(['newsletter', 'method'], '')
-        const action = this.props.footer.getIn(['newsletter', 'action'], '')
+        const {method, action} = this.props.footer.newsletter
         this.props.submitNewsletter(method, action, data)
-    }
-
-    shouldComponentUpdate(nextProps) {
-        return !Immutable.is(this.props.footer, nextProps.footer)
     }
 
     render() {
         const {footer} = this.props
-        const navigation = footer.get('navigation')
-        const newsletter = footer.get('newsletter')
-
+        const {navigation, newsletter} = footer
 
         return (
             <footer className="t-footer">
@@ -62,7 +57,7 @@ Footer.propTypes = {
 
 
 const mapStateToProps = createStructuredSelector({
-    footer: selectors.getFooter
+    footer: selectorToJS(selectors.getFooter)
 })
 
 const mapDispatchToProps = {

--- a/app/containers/footer/container.js
+++ b/app/containers/footer/container.js
@@ -1,5 +1,4 @@
 import React, {PropTypes} from 'react'
-import Immutable from 'immutable'
 import {connect} from 'react-redux'
 import {createStructuredSelector} from 'reselect'
 import {selectorToJS} from '../../utils/selector-utils'

--- a/app/containers/footer/partials/footer-navigation.jsx
+++ b/app/containers/footer/partials/footer-navigation.jsx
@@ -7,9 +7,9 @@ import SkeletonText from 'progressive-web-sdk/dist/components/skeleton-text'
 const FooterNavigation = ({navigation}) => {
     return (
         <div className="t-footer__navigation u-padding-lg u-text-align-center">
-            {navigation.map(({title, href}, key) => {
+            {navigation.map(({title, href}, index) => {
                 return (
-                    <ListTile href={href} key={key}>
+                    <ListTile href={href} key={index}>
                         {title || <SkeletonText width="135px" style={{lineHeight: '20px'}} />}
                     </ListTile>
                 )

--- a/app/containers/footer/partials/footer-navigation.jsx
+++ b/app/containers/footer/partials/footer-navigation.jsx
@@ -7,10 +7,9 @@ import SkeletonText from 'progressive-web-sdk/dist/components/skeleton-text'
 const FooterNavigation = ({navigation}) => {
     return (
         <div className="t-footer__navigation u-padding-lg u-text-align-center">
-            {navigation.map((item, key) => {
-                const title = item.get('title')
+            {navigation.map(({title, href}, key) => {
                 return (
-                    <ListTile href={item.get('href')} key={key}>
+                    <ListTile href={href} key={key}>
                         {title || <SkeletonText width="135px" style={{lineHeight: '20px'}} />}
                     </ListTile>
                 )
@@ -27,7 +26,7 @@ const FooterNavigation = ({navigation}) => {
 }
 
 FooterNavigation.propTypes = {
-    navigation: PropTypes.object
+    navigation: PropTypes.array
 }
 
 export default FooterNavigation

--- a/app/containers/header/container.js
+++ b/app/containers/header/container.js
@@ -3,6 +3,8 @@ import {connect} from 'react-redux'
 import {createStructuredSelector} from 'reselect'
 import throttle from 'lodash.throttle'
 import classnames from 'classnames'
+import {selectorToJS} from '../../utils/selector-utils'
+
 import * as headerActions from './actions'
 import * as selectors from './selectors'
 
@@ -33,8 +35,8 @@ class Header extends React.Component {
     }
 
     handleScroll() {
-        const {isCollapsed} = this.props.header.toJS()
-        const newIsCollapsed = window.pageYOffset > this.headerHeight
+        const {isCollapsed} = this.props.header
+        const newIsCollapsed = window.pageYOffset > headerHeight
 
         // Don't trigger the action unless things have changed
         if (newIsCollapsed !== isCollapsed) {
@@ -44,7 +46,7 @@ class Header extends React.Component {
 
     render() {
         const {onMenuClick, onMiniCartClick} = this.props
-        const {isCollapsed, itemCount} = this.props.header.toJS()
+        const {isCollapsed, itemCount} = this.props.header
 
         const innerButtonClassName = classnames('t-header__inner-button', 'u-padding-0', {
             't--hide-label': isCollapsed
@@ -75,7 +77,7 @@ Header.propTypes = {
 }
 
 const mapStateToProps = createStructuredSelector({
-    header: selectors.getHeader
+    header: selectorToJS(selectors.getHeader)
 })
 
 const mapDispatchToProps = {

--- a/app/containers/header/container.js
+++ b/app/containers/header/container.js
@@ -36,7 +36,7 @@ class Header extends React.Component {
 
     handleScroll() {
         const {isCollapsed} = this.props.header
-        const newIsCollapsed = window.pageYOffset > headerHeight
+        const newIsCollapsed = window.pageYOffset > this.headerHeight
 
         // Don't trigger the action unless things have changed
         if (newIsCollapsed !== isCollapsed) {

--- a/app/containers/home/container.js
+++ b/app/containers/home/container.js
@@ -8,7 +8,7 @@ import * as selectors from './selectors'
 import HomeCarousel from './partials/home-carousel'
 import HomeCategories from './partials/home-categories'
 
-class Home extends React.PureComponent {
+class Home extends React.Component {
     render() {
         const {banners, categories} = this.props.home
 

--- a/app/containers/home/container.js
+++ b/app/containers/home/container.js
@@ -2,18 +2,15 @@ import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import Immutable from 'immutable'
 import {createStructuredSelector} from 'reselect'
+import {selectorToJS} from '../../utils/selector-utils'
 
 import * as selectors from './selectors'
 import HomeCarousel from './partials/home-carousel'
 import HomeCategories from './partials/home-categories'
 
-class Home extends React.Component {
-    shouldComponentUpdate(nextProps) {
-        return !Immutable.is(this.props.home, nextProps.home)
-    }
-
+class Home extends React.PureComponent {
     render() {
-        const {banners, categories} = this.props.home.toJS()
+        const {banners, categories} = this.props.home
 
         return (
             <div className="t-home__container">
@@ -29,7 +26,7 @@ Home.propTypes = {
 }
 
 const mapStateToProps = createStructuredSelector({
-    home: selectors.getHome
+    home: selectorToJS(selectors.getHome)
 })
 
 export default connect(

--- a/app/containers/home/container.js
+++ b/app/containers/home/container.js
@@ -1,6 +1,5 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
-import Immutable from 'immutable'
 import {createStructuredSelector} from 'reselect'
 import {selectorToJS} from '../../utils/selector-utils'
 
@@ -8,17 +7,15 @@ import * as selectors from './selectors'
 import HomeCarousel from './partials/home-carousel'
 import HomeCategories from './partials/home-categories'
 
-class Home extends React.Component {
-    render() {
-        const {banners, categories} = this.props.home
+const Home = ({home}) => {
+    const {banners, categories} = home
 
-        return (
-            <div className="t-home__container">
-                <HomeCarousel banners={banners} />
-                <HomeCategories categories={categories} />
-            </div>
-        )
-    }
+    return (
+        <div className="t-home__container">
+            <HomeCarousel banners={banners} />
+            <HomeCategories categories={categories} />
+        </div>
+    )
 }
 
 Home.propTypes = {

--- a/app/containers/login/container.js
+++ b/app/containers/login/container.js
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import {withRouter} from 'react-router'
+import {selectorToJS} from '../../utils/selector-utils'
 
 import SignInForm from './partials/signin'
 import RegisterForm from './partials/register'
@@ -147,9 +148,11 @@ class Login extends React.Component {
     }
 }
 
+const loginJSSelector = selectorToJS(selectors.getLogin)
+
 const mapStateToProps = (state, props) => {
     return {
-        ...selectors.getLogin(state).toJS()
+        ...loginJSSelector(state)
     }
 }
 

--- a/app/containers/mini-cart/container.js
+++ b/app/containers/mini-cart/container.js
@@ -3,6 +3,7 @@ import {connect} from 'react-redux'
 import Immutable from 'immutable'
 import classNames from 'classnames'
 import {createStructuredSelector} from 'reselect'
+import {selectorToJS} from '../../utils/selector-utils'
 import {getAssetUrl} from 'progressive-web-sdk/dist/asset-utils'
 
 import Button from 'progressive-web-sdk/dist/components/button'
@@ -97,7 +98,7 @@ class MiniCart extends React.Component {
 
     render() {
         const {miniCart, closeMiniCart} = this.props
-        const {cart, contentsLoaded, isOpen} = miniCart.toJS()
+        const {cart, contentsLoaded, isOpen} = miniCart
         const hasItems = cart ? cart.items.length > 0 : false
 
         return (
@@ -139,7 +140,7 @@ MiniCart.propTypes = {
 }
 
 const mapStateToProps = createStructuredSelector({
-    miniCart: selectors.getMiniCart
+    miniCart: selectorToJS(selectors.getMiniCart)
 })
 
 const mapDispatchToProps = {

--- a/app/containers/navigation/container.js
+++ b/app/containers/navigation/container.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import {connect} from 'react-redux'
 import {createStructuredSelector} from 'reselect'
+import {selectorToJS} from '../../utils/selector-utils'
+
 import Nav from 'progressive-web-sdk/dist/components/nav'
 import NavMenu from 'progressive-web-sdk/dist/components/nav-menu'
 import NavItem from 'progressive-web-sdk/dist/components/nav-item'
@@ -28,9 +30,7 @@ const itemFactory = (type, props) => {
 
 const Navigation = (props) => {
     const {navigation, closeNavigation, router} = props
-    const path = navigation.get('path')
-    const isOpen = navigation.get('isOpen')
-    const root = navigation.get('root') && navigation.get('root').toJS()
+    const {path, isOpen, root} = navigation
 
     const onPathChange = (path) => {
         const url = new URL(path)
@@ -82,7 +82,7 @@ Navigation.propTypes = {
 
 
 const mapStateToProps = createStructuredSelector({
-    navigation: selectors.getNavigation
+    navigation: selectorToJS(selectors.getNavigation)
 })
 
 export default connect(

--- a/app/containers/pdp/container.js
+++ b/app/containers/pdp/container.js
@@ -1,6 +1,5 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
-import Immutable from 'immutable'
 import {createStructuredSelector} from 'reselect'
 import {selectorToJS} from '../../utils/selector-utils'
 
@@ -13,59 +12,49 @@ import {stripEvent} from '../../utils/utils'
 import * as pdpActions from './actions'
 import * as selectors from './selectors'
 
-class PDP extends React.Component {
-    render() {
-        const {
-            setQuantity,
-            addToCart,
-            closeItemAddedModal,
-            pdp,
-            catalogProduct: product
-        } = this.props
+const PDP = ({setQuantity, addToCart, closeItemAddedModal, pdp, product}) => {
+    const {
+        itemQuantity,
+        quantityAdded,
+        itemAddedModalOpen,
+        formInfo,
+        contentsLoaded
+    } = pdp
 
-        const {
-            itemQuantity,
-            quantityAdded,
-            itemAddedModalOpen,
-            formInfo,
-            contentsLoaded
-        } = pdp
-
-        const {
-            title,
-            price,
-            description,
-            carouselItems
-        } = product
+    const {
+        title,
+        price,
+        description,
+        carouselItems
+    } = product
 
 
-        return (
-            <div className="t-pdp">
-                <PDPHeading title={title} price={price} />
+    return (
+        <div className="t-pdp">
+            <PDPHeading title={title} price={price} />
 
-                <PDPCarousel items={carouselItems} contentsLoaded={contentsLoaded} />
+            <PDPCarousel items={carouselItems} contentsLoaded={contentsLoaded} />
 
-                <PDPDescription description={description} />
+            <PDPDescription description={description} />
 
-                <PDPAddToCart
-                    formInfo={formInfo}
-                    quantity={itemQuantity}
-                    setQuantity={setQuantity}
-                    onSubmit={addToCart}
-                    disabled={!contentsLoaded}
+            <PDPAddToCart
+                formInfo={formInfo}
+                quantity={itemQuantity}
+                setQuantity={setQuantity}
+                onSubmit={addToCart}
+                disabled={!contentsLoaded}
                 />
 
-                {contentsLoaded &&
-                    <PDPItemAddedModal
-                        open={itemAddedModalOpen}
-                        onDismiss={closeItemAddedModal}
-                        product={product}
-                        quantity={quantityAdded}
+            {contentsLoaded &&
+                <PDPItemAddedModal
+                    open={itemAddedModalOpen}
+                    onDismiss={closeItemAddedModal}
+                    product={product}
+                    quantity={quantityAdded}
                     />
                 }
-            </div>
-        )
-    }
+        </div>
+    )
 }
 
 PDP.propTypes = {
@@ -73,10 +62,6 @@ PDP.propTypes = {
      * Function to submit the add-to-cart form
      */
     addToCart: PropTypes.func.isRequired,
-    /**
-     * Product data from state (Catalog -> Products)
-     */
-    catalogProduct: PropTypes.object.isRequired,
     /**
      * Callback when the added-to-cart modal closes
      */
@@ -86,13 +71,17 @@ PDP.propTypes = {
      */
     pdp: PropTypes.object.isRequired,
     /**
+     * Product data from state (Catalog -> Products)
+     */
+    product: PropTypes.object.isRequired,
+    /**
      * Function to update the item quantity when user changes it
      */
     setQuantity: PropTypes.func.isRequired,
 }
 
 export const mapStateToProps = createStructuredSelector({
-    catalogProduct: selectorToJS(selectors.getSelectedProduct),
+    product: selectorToJS(selectors.getSelectedProduct),
     pdp: selectorToJS(selectors.getSelectedPdp)
 })
 

--- a/app/containers/pdp/container.js
+++ b/app/containers/pdp/container.js
@@ -1,7 +1,8 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import Immutable from 'immutable'
-import {createSelector} from 'reselect'
+import {createStructuredSelector} from 'reselect'
+import {selectorToJS} from '../../utils/selector-utils'
 
 import PDPHeading from './partials/pdp-heading'
 import PDPCarousel from './partials/pdp-carousel'
@@ -11,23 +12,24 @@ import PDPItemAddedModal from './partials/pdp-item-added-modal'
 import {stripEvent} from '../../utils/utils'
 import * as pdpActions from './actions'
 import * as selectors from './selectors'
-import {getSelectorFromState} from '../../utils/router-utils'
 
 class PDP extends React.Component {
-    shouldComponentUpdate(newProps) {
-        return !Immutable.is(newProps.pdp, this.props.pdp) || !Immutable.is(newProps.catalogProduct, this.props.catalogProduct)
-    }
-
     render() {
+        const {
+            setQuantity,
+            addToCart,
+            closeItemAddedModal,
+            pdp,
+            catalogProduct: product
+        } = this.props
+
         const {
             itemQuantity,
             quantityAdded,
             itemAddedModalOpen,
             formInfo,
             contentsLoaded
-        } = this.props.pdp.toJS()
-
-        const product = this.props.catalogProduct.toJS()
+        } = pdp
 
         const {
             title,
@@ -36,11 +38,6 @@ class PDP extends React.Component {
             carouselItems
         } = product
 
-        const {
-            setQuantity,
-            addToCart,
-            closeItemAddedModal
-        } = this.props
 
         return (
             <div className="t-pdp">
@@ -94,17 +91,10 @@ PDP.propTypes = {
     setQuantity: PropTypes.func.isRequired,
 }
 
-export const mapStateToProps = createSelector(
-    selectors.getCatalog,
-    selectors.getPdp,
-    (catalog, pdp) => {
-        const selector = getSelectorFromState(pdp)
-        return {
-            catalogProduct: catalog.products.get(selector),
-            pdp: pdp.get(selector)
-        }
-    }
-)
+export const mapStateToProps = createStructuredSelector({
+    catalogProduct: selectorToJS(selectors.getSelectedProduct),
+    pdp: selectorToJS(selectors.getSelectedPdp)
+})
 
 const mapDispatchToProps = {
     setQuantity: pdpActions.setItemQuantity,

--- a/app/containers/pdp/selectors.js
+++ b/app/containers/pdp/selectors.js
@@ -1,8 +1,25 @@
 import {createSelector} from 'reselect'
 import * as globalSelectors from '../../store/selectors'
+import {SELECTOR} from '../app/constants'
 
 export const getPdp = createSelector(
     globalSelectors.getUi,
     ({pdp}) => pdp
 )
-export const getCatalog = globalSelectors.getCatalog
+
+export const getPdpSelector = createSelector(
+    getPdp,
+    (pdp) => pdp.get(SELECTOR)
+)
+
+export const getSelectedPdp = createSelector(
+    getPdp,
+    getPdpSelector,
+    (pdp, pdpSelector) => pdp.get(pdpSelector)
+)
+
+export const getSelectedProduct = createSelector(
+    globalSelectors.getCatalogProducts,
+    getPdpSelector,
+    (products, pdpSelector) => products.get(pdpSelector)
+)

--- a/app/containers/pdp/selectors.js
+++ b/app/containers/pdp/selectors.js
@@ -1,6 +1,6 @@
 import {createSelector} from 'reselect'
 import * as globalSelectors from '../../store/selectors'
-import {SELECTOR} from '../app/constants'
+import {getSelectorFromState} from '../../utils/router-utils'
 
 export const getPdp = createSelector(
     globalSelectors.getUi,
@@ -9,7 +9,7 @@ export const getPdp = createSelector(
 
 export const getPdpSelector = createSelector(
     getPdp,
-    (pdp) => pdp.get(SELECTOR)
+    getSelectorFromState
 )
 
 export const getSelectedPdp = createSelector(

--- a/app/containers/plp/container.js
+++ b/app/containers/plp/container.js
@@ -36,10 +36,6 @@ const renderNoResults = (bodyText) => {
 }
 
 class PLP extends React.Component {
-    shouldComponentUpdate(nextProps) {
-        return this.props.plp !== nextProps.plp || !Immutable.is(nextProps.products, this.props.products)
-    }
-
     render() {
         const {
             hasProducts,

--- a/app/containers/plp/container.js
+++ b/app/containers/plp/container.js
@@ -2,7 +2,8 @@ import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import Immutable from 'immutable'
 import {getAssetUrl} from 'progressive-web-sdk/dist/asset-utils'
-import {createSelector} from 'reselect'
+import {createStructuredSelector} from 'reselect'
+import {selectorToJS} from '../../utils/selector-utils'
 
 import * as selectors from './selectors'
 import Image from 'progressive-web-sdk/dist/components/image'
@@ -36,7 +37,7 @@ const renderNoResults = (bodyText) => {
 
 class PLP extends React.Component {
     shouldComponentUpdate(nextProps) {
-        return !Immutable.is(this.props.plp, nextProps.plp) || !Immutable.is(nextProps.products, this.props.products)
+        return this.props.plp !== nextProps.plp || !Immutable.is(nextProps.products, this.props.products)
     }
 
     render() {
@@ -46,7 +47,7 @@ class PLP extends React.Component {
             noResultsText,
             numItems,
             title
-        } = this.props.plp.toJS()
+        } = this.props.plp
 
         const products = this.props.products
 
@@ -108,23 +109,10 @@ PLP.propTypes = {
     products: PropTypes.array.isRequired
 }
 
-const mapStateToProps = createSelector(
-    selectors.getCatalog,
-    selectors.getPlp,
-    (catalog, plp) => {
-        const selector = getSelectorFromState(plp)
-        const routedPlp = plp.get(selector)
-        const productUrls = routedPlp.get('productUrls').toJS()
-        const catalogProducts = catalog.products
-        const products = productUrls.map((url) => {
-            return catalogProducts.get(url).toJS()
-        })
-        return {
-            products,
-            plp: routedPlp
-        }
-    }
-)
+const mapStateToProps = createStructuredSelector({
+    products: selectorToJS(selectors.getPlpProducts),
+    plp: selectorToJS(selectors.getSelectedPlp)
+})
 
 export default connect(
     mapStateToProps

--- a/app/containers/plp/container.js
+++ b/app/containers/plp/container.js
@@ -1,6 +1,5 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
-import Immutable from 'immutable'
 import {getAssetUrl} from 'progressive-web-sdk/dist/asset-utils'
 import {createStructuredSelector} from 'reselect'
 import {selectorToJS} from '../../utils/selector-utils'
@@ -12,7 +11,6 @@ import List from 'progressive-web-sdk/dist/components/list'
 import SkeletonText from 'progressive-web-sdk/dist/components/skeleton-text'
 import SkeletonBlock from 'progressive-web-sdk/dist/components/skeleton-block'
 import ProductTile from './partials/product-tile'
-import {getSelectorFromState} from '../../utils/router-utils'
 
 const renderResults = (products) => {
     return products.map((product, idx) => <ProductTile key={idx} product={product} />)
@@ -35,64 +33,61 @@ const renderNoResults = (bodyText) => {
     )
 }
 
-class PLP extends React.Component {
-    render() {
-        const {
-            hasProducts,
-            contentsLoaded,
-            noResultsText,
-            numItems,
-            title
-        } = this.props.plp
+const PLP = ({plp, products}) => {
+    const {
+        hasProducts,
+        contentsLoaded,
+        noResultsText,
+        numItems,
+        title
+    } = plp
 
-        const products = this.props.products
-
-        return (
-            <div className="t-plp">
-                <div className="u-flexbox u-align-bottom">
-                    <div className="u-flex u-padding-top-lg u-padding-bottom-lg u-padding-start-md">
-                        <div className="t-plp__breadcrumb">
-                            <Link href="/" className="u-text-small">Home</Link>
-                        </div>
-
-                        <div className="u-margin-top-md">
-                            {contentsLoaded ?
-                                <h1 className="u-text-lighter u-text-uppercase">{title}</h1>
-                            :
-                                <SkeletonText lines={1} type="h1" width="100px" />
-                            }
-                        </div>
+    return (
+        <div className="t-plp">
+            <div className="u-flexbox u-align-bottom">
+                <div className="u-flex u-padding-top-lg u-padding-bottom-lg u-padding-start-md">
+                    <div className="t-plp__breadcrumb">
+                        <Link href="/" className="u-text-small">Home</Link>
                     </div>
 
-                    {title &&
-                        <Image
-                            className="u-flex-none u-padding-end u-padding-bottom-sm"
-                            alt="Heading logo"
-                            height="60px"
-                            width="60px"
-                            src={getAssetUrl(`static/img/categories/${title.trim().replace(/\s+/g, '-')
-                            .toLowerCase()}@2x.png`)}
-                        />
+                    <div className="u-margin-top-md">
+                        {contentsLoaded ?
+                            <h1 className="u-text-lighter u-text-uppercase">{title}</h1>
+                        :
+                            <SkeletonText lines={1} type="h1" width="100px" />
+                        }
+                    </div>
+                </div>
+
+                {title &&
+                    <Image
+                        className="u-flex-none u-padding-end u-padding-bottom-sm"
+                        alt="Heading logo"
+                        height="60px"
+                        width="60px"
+                        src={getAssetUrl(`static/img/categories/${title.trim().replace(/\s+/g, '-')
+                        .toLowerCase()}@2x.png`)}
+                    />
+                }
+            </div>
+
+            <div className="t-plp__container u-padding-end u-padding-bottom-lg u-padding-start">
+                <div className="t-plp__num-results u-padding-md">
+                    {contentsLoaded ?
+                        <span className="u-text-semi-bold">{numItems} Results</span>
+                    :
+                        <SkeletonBlock height="20px" />
                     }
                 </div>
 
-                <div className="t-plp__container u-padding-end u-padding-bottom-lg u-padding-start">
-                    <div className="t-plp__num-results u-padding-md">
-                        {contentsLoaded ?
-                            <span className="u-text-semi-bold">{numItems} Results</span>
-                        :
-                            <SkeletonBlock height="20px" />
-                        }
-                    </div>
-
-                    <List className="c--borderless">
-                        {hasProducts ? renderResults(products) : renderNoResults(noResultsText)}
-                    </List>
-                </div>
+                <List className="c--borderless">
+                    {hasProducts ? renderResults(products) : renderNoResults(noResultsText)}
+                </List>
             </div>
-        )
-    }
+        </div>
+    )
 }
+
 
 PLP.propTypes = {
     /**

--- a/app/containers/plp/selectors.js
+++ b/app/containers/plp/selectors.js
@@ -1,9 +1,32 @@
 import {createSelector} from 'reselect'
 import * as globalSelectors from '../../store/selectors'
+import {getSelectorFromState} from '../../utils/router-utils'
 
-export const getCatalog = globalSelectors.getCatalog
+export const getCatalogProducts = globalSelectors.getCatalogProducts
 
 export const getPlp = createSelector(
     globalSelectors.getUi,
     ({plp}) => plp
+)
+
+export const getPlpSelector = createSelector(
+    getPlp,
+    getSelectorFromState
+)
+
+export const getSelectedPlp = createSelector(
+    getPlp,
+    getPlpSelector,
+    (plp, plpSelector) => plp.get(plpSelector)
+)
+
+export const getProductUrls = createSelector(
+    getSelectedPlp,
+    (plp) => plp.get('productUrls')
+)
+
+export const getPlpProducts = createSelector(
+    globalSelectors.getCatalogProducts,
+    getProductUrls,
+    (products, productUrls) => productUrls.map((url) => products.get(url))
 )

--- a/app/store/selectors.js
+++ b/app/store/selectors.js
@@ -1,2 +1,8 @@
+import {createSelector} from 'reselect'
+
 export const getUi = ({ui}) => ui
 export const getCatalog = ({catalog}) => catalog
+export const getCatalogProducts = createSelector(
+    getCatalog,
+    ({products}) => products
+)

--- a/app/utils/selector-utils.js
+++ b/app/utils/selector-utils.js
@@ -6,7 +6,9 @@ export const createImmutableComparingSelector = createSelectorCreator(
     Immutable.is
 )
 
-export const createToJSSelector = (...args) => createImmutableComparingSelector(
-    createSelector(...args),
+export const selectorToJS = (selector) => createImmutableComparingSelector(
+    selector,
     (raw) => raw.toJS()
 )
+
+export const createToJSSelector = (...args) => selectorToJS(createSelector(...args))

--- a/app/utils/selector-utils.js
+++ b/app/utils/selector-utils.js
@@ -1,0 +1,12 @@
+import {createSelector, createSelectorCreator, defaultMemoize} from 'reselect'
+import Immutable from 'immutable'
+
+export const createImmutableComparingSelector = createSelectorCreator(
+    defaultMemoize,
+    Immutable.is
+)
+
+export const createToJSSelector = (...args) => createImmutableComparingSelector(
+    createSelector(...args),
+    (raw) => raw.toJS()
+)

--- a/app/utils/selector-utils.test.js
+++ b/app/utils/selector-utils.test.js
@@ -1,0 +1,31 @@
+import Immutable from 'immutable'
+import {createSelector} from 'reselect'
+
+import {createToJSSelector} from './selector-utils'
+
+test('Creates identical JS objects when the Immutable objects don\'t change', () => {
+    const rootSelector = (state) => state
+    const selector = createToJSSelector(
+        rootSelector,
+        ({contents}) => contents
+    )
+
+    const referenceSelector = createSelector(
+        rootSelector,
+        ({contents}) => contents.toJS()
+    )
+
+    const state1 = {
+        contents: Immutable.List([1, 2, 3])
+    }
+
+    const state2 = {
+        contents: Immutable.List([1, 2]).push(3)
+    }
+
+    expect(state1.contents).not.toBe(state2.contents)
+    expect(Immutable.is(state1.contents, state2.contents)).toBe(true)
+
+    expect(referenceSelector(state1)).not.toBe(referenceSelector(state2))
+    expect(selector(state1)).toBe(selector(state2))
+})


### PR DESCRIPTION
This PR adds the `selectorToJS` utility function which will handle the Immutable -> JS conversion in a way that preserves the JS object. This, combined with writing the `mapStateToProps` function as a Reselect selector, allows `react-redux` to determine on its own whether a connected component needs to be updated.

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1032

## Changes
- Add utility functions for handling Immutable using Reselect
- Convert all the containers to use them
- Convert a number of containers to stateless components.

## How to test-drive this PR
- Run the tests
- Preview Merlins and see that everything works.