### PR TITLE
Break up store access

### DIFF
--- a/app/containers/app/container.js
+++ b/app/containers/app/container.js
@@ -36,17 +36,16 @@ class App extends React.Component {
 
     render() {
         const {
-            app,
             children,
             history,
             notificationActions,
+            notifications,
             openNavigation,
             requestOpenMiniCart,
         } = this.props
         const currentTemplateProps = children.props
         const CurrentHeader = currentTemplateProps.route.Header || Header
         const CurrentFooter = currentTemplateProps.route.Footer || Footer
-        const {notifications} = app
 
         const skipLinksItems = [
             // Customize your list of SkipLinks here. These are necessary to
@@ -105,15 +104,15 @@ App.propTypes = {
     /**
      * The react-router history object
      */
-    app: PropTypes.object,
     history: PropTypes.object,
+    notifications: PropTypes.array,
     notificationActions: PropTypes.object,
     openNavigation: PropTypes.func,
     requestOpenMiniCart: PropTypes.func,
 }
 
 const mapStateToProps = createStructuredSelector({
-    app: selectorToJS(selectors.getApp)
+    notifications: selectorToJS(selectors.getNotifications)
 })
 
 const mapDispatchToProps = (dispatch) => {

--- a/app/containers/app/container.js
+++ b/app/containers/app/container.js
@@ -105,8 +105,8 @@ App.propTypes = {
      * The react-router history object
      */
     history: PropTypes.object,
-    notifications: PropTypes.array,
     notificationActions: PropTypes.object,
+    notifications: PropTypes.array,
     openNavigation: PropTypes.func,
     requestOpenMiniCart: PropTypes.func,
 }

--- a/app/containers/app/selectors.js
+++ b/app/containers/app/selectors.js
@@ -11,3 +11,8 @@ export const getCurrentUrl = createSelector(
     getApp,
     (app) => app.get(CURRENT_URL)
 )
+
+export const getNotifications = createSelector(
+    getApp,
+    (app) => app.get('notifications')
+)

--- a/app/containers/app/selectors.js
+++ b/app/containers/app/selectors.js
@@ -1,4 +1,5 @@
 import {createSelector} from 'reselect'
+import {createGetSelector} from '../../utils/selector-utils'
 import * as globalSelectors from '../../store/selectors'
 import {CURRENT_URL} from './constants'
 
@@ -7,10 +8,7 @@ export const getApp = createSelector(
     ({app}) => app
 )
 
-export const getCurrentUrl = createSelector(
-    getApp,
-    (app) => app.get(CURRENT_URL)
-)
+export const getCurrentUrl = createGetSelector(getApp, CURRENT_URL)
 
 export const getNotifications = createSelector(
     getApp,

--- a/app/containers/app/selectors.js
+++ b/app/containers/app/selectors.js
@@ -9,8 +9,4 @@ export const getApp = createSelector(
 )
 
 export const getCurrentUrl = createGetSelector(getApp, CURRENT_URL)
-
-export const getNotifications = createSelector(
-    getApp,
-    (app) => app.get('notifications')
-)
+export const getNotifications = createGetSelector(getApp, 'notifications')

--- a/app/containers/header/container.js
+++ b/app/containers/header/container.js
@@ -3,7 +3,6 @@ import {connect} from 'react-redux'
 import {createStructuredSelector} from 'reselect'
 import throttle from 'lodash.throttle'
 import classnames from 'classnames'
-import {selectorToJS} from '../../utils/selector-utils'
 
 import * as headerActions from './actions'
 import * as selectors from './selectors'

--- a/app/containers/header/container.js
+++ b/app/containers/header/container.js
@@ -35,7 +35,7 @@ class Header extends React.Component {
     }
 
     handleScroll() {
-        const {isCollapsed} = this.props.header
+        const {isCollapsed} = this.props
         const newIsCollapsed = window.pageYOffset > this.headerHeight
 
         // Don't trigger the action unless things have changed
@@ -45,8 +45,7 @@ class Header extends React.Component {
     }
 
     render() {
-        const {onMenuClick, onMiniCartClick} = this.props
-        const {isCollapsed, itemCount} = this.props.header
+        const {onMenuClick, onMiniCartClick, isCollapsed, itemCount} = this.props
 
         const innerButtonClassName = classnames('t-header__inner-button', 'u-padding-0', {
             't--hide-label': isCollapsed
@@ -69,7 +68,8 @@ class Header extends React.Component {
 }
 
 Header.propTypes = {
-    header: PropTypes.object,
+    isCollapsed: PropTypes.bool,
+    itemCount: PropTypes.number,
     toggleHeader: PropTypes.func,
 
     onMenuClick: PropTypes.func,
@@ -77,7 +77,8 @@ Header.propTypes = {
 }
 
 const mapStateToProps = createStructuredSelector({
-    header: selectorToJS(selectors.getHeader)
+    isCollapsed: selectors.getIsCollapsed,
+    itemCount: selectors.getItemCount
 })
 
 const mapDispatchToProps = {

--- a/app/containers/header/selectors.js
+++ b/app/containers/header/selectors.js
@@ -1,16 +1,10 @@
 import {createSelector} from 'reselect'
+import {createGetSelector} from '../../utils/selector-utils'
 import * as globalSelectors from '../../store/selectors'
 export const getHeader = createSelector(
     globalSelectors.getUi,
     ({header}) => header
 )
 
-export const getIsCollapsed = createSelector(
-    getHeader,
-    (header) => header.get('isCollapsed')
-)
-
-export const getItemCount = createSelector(
-    getHeader,
-    (header) => header.get('itemCount')
-)
+export const getIsCollapsed = createGetSelector(getHeader, 'isCollapsed')
+export const getItemCount = createGetSelector(getHeader, 'itemCount')

--- a/app/containers/header/selectors.js
+++ b/app/containers/header/selectors.js
@@ -4,3 +4,13 @@ export const getHeader = createSelector(
     globalSelectors.getUi,
     ({header}) => header
 )
+
+export const getIsCollapsed = createSelector(
+    getHeader,
+    (header) => header.get('isCollapsed')
+)
+
+export const getItemCount = createSelector(
+    getHeader,
+    (header) => header.get('itemCount')
+)

--- a/app/containers/home/container.js
+++ b/app/containers/home/container.js
@@ -7,8 +7,7 @@ import * as selectors from './selectors'
 import HomeCarousel from './partials/home-carousel'
 import HomeCategories from './partials/home-categories'
 
-const Home = ({home}) => {
-    const {banners, categories} = home
+const Home = ({banners, categories}) => {
 
     return (
         <div className="t-home__container">
@@ -19,11 +18,13 @@ const Home = ({home}) => {
 }
 
 Home.propTypes = {
-    home: PropTypes.object.isRequired
+    banners: PropTypes.array.isRequired,
+    categories: PropTypes.array.isRequired
 }
 
 const mapStateToProps = createStructuredSelector({
-    home: selectorToJS(selectors.getHome)
+    banners: selectorToJS(selectors.getHomeBanners),
+    categories: selectorToJS(selectors.getHomeCategories)
 })
 
 export default connect(

--- a/app/containers/home/selectors.js
+++ b/app/containers/home/selectors.js
@@ -1,4 +1,5 @@
 import {createSelector} from 'reselect'
+import {createGetSelector} from '../../utils/selector-utils'
 import * as globalSelectors from '../../store/selectors'
 
 export const getHome = createSelector(
@@ -6,12 +7,5 @@ export const getHome = createSelector(
     ({home}) => home
 )
 
-export const getHomeBanners = createSelector(
-    getHome,
-    (home) => home.get('banners')
-)
-
-export const getHomeCategories = createSelector(
-    getHome,
-    (home) => home.get('categories')
-)
+export const getHomeBanners = createGetSelector(getHome, 'banners')
+export const getHomeCategories = createGetSelector(getHome, 'categories')

--- a/app/containers/home/selectors.js
+++ b/app/containers/home/selectors.js
@@ -5,3 +5,13 @@ export const getHome = createSelector(
     globalSelectors.getUi,
     ({home}) => home
 )
+
+export const getHomeBanners = createSelector(
+    getHome,
+    (home) => home.get('banners')
+)
+
+export const getHomeCategories = createSelector(
+    getHome,
+    (home) => home.get('categories')
+)

--- a/app/containers/login/container.js
+++ b/app/containers/login/container.js
@@ -1,5 +1,6 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
+import {createStructuredSelector} from 'reselect'
 import {withRouter} from 'react-router'
 import {selectorToJS} from '../../utils/selector-utils'
 
@@ -148,13 +149,12 @@ class Login extends React.Component {
     }
 }
 
-const loginJSSelector = selectorToJS(selectors.getLogin)
-
-const mapStateToProps = (state, props) => {
-    return {
-        ...loginJSSelector(state)
-    }
-}
+const mapStateToProps = createStructuredSelector({
+    title: selectors.getLoginTitle,
+    signinSection: selectorToJS(selectors.getSigninSection),
+    registerSection: selectorToJS(selectors.getRegisterSection),
+    loaded: selectors.getLoginLoaded
+})
 
 const mapDispatchToProps = {
     submitSignInForm: actions.submitSignInForm,

--- a/app/containers/login/selectors.js
+++ b/app/containers/login/selectors.js
@@ -1,7 +1,13 @@
 import {createSelector} from 'reselect'
+import {createGetSelector} from '../../utils/selector-utils'
 import * as globalSelectors from '../../store/selectors'
 
 export const getLogin = createSelector(
     globalSelectors.getUi,
     ({login}) => login
 )
+
+export const getLoginTitle = createGetSelector(getLogin, 'title')
+export const getSigninSection = createGetSelector(getLogin, 'signinSection')
+export const getRegisterSection = createGetSelector(getLogin, 'registerSection')
+export const getLoginLoaded = createGetSelector(getLogin, 'loaded')

--- a/app/containers/mini-cart/container.js
+++ b/app/containers/mini-cart/container.js
@@ -129,10 +129,10 @@ class MiniCart extends React.Component {
 
 MiniCart.propTypes = {
     cart: PropTypes.object.isRequired,
-    contentsLoaded: PropTypes.bool,
-    isOpen: PropTypes.bool,
     closeMiniCart: PropTypes.func,
+    contentsLoaded: PropTypes.bool,
     fetchContents: PropTypes.func,
+    isOpen: PropTypes.bool,
 }
 
 const mapStateToProps = createStructuredSelector({

--- a/app/containers/mini-cart/container.js
+++ b/app/containers/mini-cart/container.js
@@ -1,6 +1,5 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
-import Immutable from 'immutable'
 import classNames from 'classnames'
 import {createStructuredSelector} from 'reselect'
 import {selectorToJS} from '../../utils/selector-utils'
@@ -29,10 +28,6 @@ export const productSubtotal = (price, quantity) => {
 class MiniCart extends React.Component {
     componentDidMount() {
         this.props.fetchContents()
-    }
-
-    shouldComponentUpdate(newProps) {
-        return !Immutable.is(newProps.miniCart, this.props.miniCart)
     }
 
     renderList(cart) {
@@ -97,8 +92,7 @@ class MiniCart extends React.Component {
     }
 
     render() {
-        const {miniCart, closeMiniCart} = this.props
-        const {cart, contentsLoaded, isOpen} = miniCart
+        const {cart, contentsLoaded, isOpen, closeMiniCart} = this.props
         const hasItems = cart ? cart.items.length > 0 : false
 
         return (
@@ -134,13 +128,17 @@ class MiniCart extends React.Component {
 }
 
 MiniCart.propTypes = {
-    miniCart: PropTypes.object.isRequired,
+    cart: PropTypes.object.isRequired,
+    contentsLoaded: PropTypes.bool,
+    isOpen: PropTypes.bool,
     closeMiniCart: PropTypes.func,
     fetchContents: PropTypes.func,
 }
 
 const mapStateToProps = createStructuredSelector({
-    miniCart: selectorToJS(selectors.getMiniCart)
+    cart: selectorToJS(selectors.getCartObject),
+    contentsLoaded: selectors.getMiniCartContentsLoaded,
+    isOpen: selectors.getMiniCartIsOpen
 })
 
 const mapDispatchToProps = {

--- a/app/containers/mini-cart/selectors.js
+++ b/app/containers/mini-cart/selectors.js
@@ -1,7 +1,12 @@
 import {createSelector} from 'reselect'
+import {createGetSelector} from '../../utils/selector-utils'
 import * as globalSelectors from '../../store/selectors'
 
 export const getMiniCart = createSelector(
     globalSelectors.getUi,
     ({miniCart}) => miniCart
 )
+
+export const getCartObject = createGetSelector(getMiniCart, 'cart')
+export const getMiniCartContentsLoaded = createGetSelector(getMiniCart, 'contentsLoaded')
+export const getMiniCartIsOpen = createGetSelector(getMiniCart, 'isOpen')

--- a/app/containers/navigation/container.js
+++ b/app/containers/navigation/container.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import {createStructuredSelector} from 'reselect'
 import {selectorToJS} from '../../utils/selector-utils'
@@ -29,8 +29,7 @@ const itemFactory = (type, props) => {
 
 
 const Navigation = (props) => {
-    const {navigation, closeNavigation, router} = props
-    const {path, isOpen, root} = navigation
+    const {path, isOpen, root, closeNavigation, router} = props
 
     const onPathChange = (path) => {
         const url = new URL(path)
@@ -43,7 +42,7 @@ const Navigation = (props) => {
 
     return (
         <Sheet className="t-navigation" open={isOpen} onDismiss={closeNavigation} maskOpacity={0.7}>
-            <Nav root={root} path={path} onPathChange={onPathChange}>
+            <Nav root={root.title ? root : null} path={path} onPathChange={onPathChange}>
                 <HeaderBar>
                     <HeaderBarTitle className="u-flex u-padding-start u-text-align-start">
                         <h2 className="t-navigation__title u-heading-family u-text-uppercase">
@@ -67,22 +66,22 @@ Navigation.propTypes = {
     /**
      * A function used to set the navigation-sheet's state to closed
      */
-    closeNavigation: React.PropTypes.func,
+    closeNavigation: PropTypes.func,
 
-    /**
-     * The immutableJS data for the nav.
-     */
-    navigation: React.PropTypes.object,
-
+    isOpen: PropTypes.bool,
+    path: PropTypes.string,
+    root: PropTypes.object,
     /**
      * The react-router router object.
      */
-    router: React.PropTypes.object,
+    router: PropTypes.object,
 }
 
 
 const mapStateToProps = createStructuredSelector({
-    navigation: selectorToJS(selectors.getNavigation)
+    path: selectors.getPath,
+    isOpen: selectors.getNavigationIsOpen,
+    root: selectorToJS(selectors.getNavigationRoot)
 })
 
 export default connect(

--- a/app/containers/navigation/reducer.js
+++ b/app/containers/navigation/reducer.js
@@ -4,10 +4,10 @@ import * as appActions from '../app/actions'
 import * as navActions from './actions'
 import * as parser from './parsers/parser'
 
-export const initialState = Immutable.Map({
+export const initialState = Immutable.fromJS({
     isOpen: false,
     path: undefined,
-    root: undefined,
+    root: {},
 })
 
 

--- a/app/containers/navigation/selectors.js
+++ b/app/containers/navigation/selectors.js
@@ -1,7 +1,12 @@
 import {createSelector} from 'reselect'
+import {createGetSelector} from '../../utils/selector-utils'
 import * as globalSelectors from '../../store/selectors'
 
 export const getNavigation = createSelector(
     globalSelectors.getUi,
     ({navigation}) => navigation
 )
+
+export const getPath = createGetSelector(getNavigation, 'path')
+export const getNavigationIsOpen = createGetSelector(getNavigation, 'isOpen')
+export const getNavigationRoot = createGetSelector(getNavigation, 'root')

--- a/app/containers/pdp/actions.js
+++ b/app/containers/pdp/actions.js
@@ -1,6 +1,7 @@
 import {createAction, makeFormEncodedRequest} from '../../utils/utils'
 import {getCart} from '../cart/actions'
 import {getRoutedState} from '../../utils/router-utils'
+import * as selectors from './selectors'
 
 export const setItemQuantity = createAction('Set item quantity')
 
@@ -8,7 +9,7 @@ export const openItemAddedModal = createAction('Open Item Added Sheet')
 export const closeItemAddedModal = createAction('Close Item Added Sheet')
 
 export const submitCartForm = () => (dispatch, getStore) => {
-    const routedState = getRoutedState(getStore().pdp)
+    const routedState = getRoutedState(selectors.getPdp(getStore()))
     const formInfo = routedState.get('formInfo')
     const qty = routedState.get('itemQuantity')
 

--- a/app/containers/pdp/actions.test.js
+++ b/app/containers/pdp/actions.test.js
@@ -23,7 +23,7 @@ test('submitCartForm makes a request and dispatches updates', () => {
     const thunk = submitCartForm()
     expect(typeof thunk).toBe('function')
 
-    const getStore = () => ({pdp: {
+    const getStore = () => ({ui: {pdp: {
         get: () => {
             return Immutable.fromJS({
                 contentsLoaded: true,
@@ -35,8 +35,7 @@ test('submitCartForm makes a request and dispatches updates', () => {
                 itemQuantity: 1
             })
         }
-    }
-    })
+    }}})
 
     const mockDispatch = jest.fn()
     return thunk(mockDispatch, getStore)

--- a/app/containers/pdp/container.js
+++ b/app/containers/pdp/container.js
@@ -12,23 +12,20 @@ import {stripEvent} from '../../utils/utils'
 import * as pdpActions from './actions'
 import * as selectors from './selectors'
 
-const PDP = ({setQuantity, addToCart, closeItemAddedModal, pdp, product}) => {
-    const {
-        itemQuantity,
-        quantityAdded,
-        itemAddedModalOpen,
-        formInfo,
-        contentsLoaded
-    } = pdp
-
-    const {
-        title,
-        price,
-        description,
-        carouselItems
-    } = product
-
-
+const PDP = ({
+    setQuantity,
+    addToCart,
+    closeItemAddedModal,
+    itemQuantity,
+    quantityAdded,
+    itemAddedModalOpen,
+    formInfo,
+    contentsLoaded,
+    title,
+    price,
+    description,
+    carouselItems
+}) => {
     return (
         <div className="t-pdp">
             <PDPHeading title={title} price={price} />
@@ -49,7 +46,7 @@ const PDP = ({setQuantity, addToCart, closeItemAddedModal, pdp, product}) => {
                 <PDPItemAddedModal
                     open={itemAddedModalOpen}
                     onDismiss={closeItemAddedModal}
-                    product={product}
+                    product={{title, price, description, carouselItems}}
                     quantity={quantityAdded}
                     />
                 }
@@ -62,27 +59,35 @@ PDP.propTypes = {
      * Function to submit the add-to-cart form
      */
     addToCart: PropTypes.func.isRequired,
+    carouselItems: PropTypes.array,
     /**
      * Callback when the added-to-cart modal closes
      */
     closeItemAddedModal: PropTypes.func.isRequired,
-    /**
-     * The Immutable.js PDP state object
-     */
-    pdp: PropTypes.object.isRequired,
-    /**
-     * Product data from state (Catalog -> Products)
-     */
-    product: PropTypes.object.isRequired,
+    contentsLoaded: PropTypes.bool,
+    description: PropTypes.string,
+    formInfo: PropTypes.object,
+    itemAddedModalOpen: PropTypes.bool,
+    itemQuantity: PropTypes.number,
+    price: PropTypes.string,
+    quantityAdded: PropTypes.number,
     /**
      * Function to update the item quantity when user changes it
      */
     setQuantity: PropTypes.func.isRequired,
+    title: PropTypes.string
 }
 
 export const mapStateToProps = createStructuredSelector({
-    product: selectorToJS(selectors.getSelectedProduct),
-    pdp: selectorToJS(selectors.getSelectedPdp)
+    title: selectors.getProductTitle,
+    price: selectors.getProductPrice,
+    description: selectors.getProductDescription,
+    carouselItems: selectorToJS(selectors.getProductCarouselItems),
+    itemQuantity: selectors.getItemQuantity,
+    quantityAdded: selectors.getQuantityAdded,
+    itemAddedModalOpen: selectors.getItemAddedModalOpen,
+    formInfo: selectorToJS(selectors.getFormInfo),
+    contentsLoaded: selectors.getPdpContentsLoaded
 })
 
 const mapDispatchToProps = {

--- a/app/containers/pdp/container.js
+++ b/app/containers/pdp/container.js
@@ -59,11 +59,15 @@ PDP.propTypes = {
      * Function to submit the add-to-cart form
      */
     addToCart: PropTypes.func.isRequired,
-    carouselItems: PropTypes.array,
     /**
      * Callback when the added-to-cart modal closes
      */
     closeItemAddedModal: PropTypes.func.isRequired,
+    /**
+     * Function to update the item quantity when user changes it
+     */
+    setQuantity: PropTypes.func.isRequired,
+    carouselItems: PropTypes.array,
     contentsLoaded: PropTypes.bool,
     description: PropTypes.string,
     formInfo: PropTypes.object,
@@ -71,10 +75,6 @@ PDP.propTypes = {
     itemQuantity: PropTypes.number,
     price: PropTypes.string,
     quantityAdded: PropTypes.number,
-    /**
-     * Function to update the item quantity when user changes it
-     */
-    setQuantity: PropTypes.func.isRequired,
     title: PropTypes.string
 }
 

--- a/app/containers/pdp/reducer.js
+++ b/app/containers/pdp/reducer.js
@@ -12,6 +12,7 @@ import {SELECTOR, PLACEHOLDER} from '../app/constants'
 
 export const initialState = Immutable.fromJS({
     contentsLoaded: false,
+    formInfo: {},
     itemQuantity: 1,
     itemAddedModalOpen: false,
     quantityAdded: 0

--- a/app/containers/pdp/selectors.js
+++ b/app/containers/pdp/selectors.js
@@ -1,4 +1,5 @@
 import {createSelector} from 'reselect'
+import {createGetSelector} from '../../utils/selector-utils'
 import * as globalSelectors from '../../store/selectors'
 import {getSelectorFromState} from '../../utils/router-utils'
 
@@ -23,3 +24,14 @@ export const getSelectedProduct = createSelector(
     getPdpSelector,
     (products, pdpSelector) => products.get(pdpSelector)
 )
+
+export const getItemQuantity = createGetSelector(getSelectedPdp, 'itemQuantity')
+export const getQuantityAdded = createGetSelector(getSelectedPdp, 'quantityAdded')
+export const getItemAddedModalOpen = createGetSelector(getSelectedPdp, 'itemAddedModalOpen')
+export const getFormInfo = createGetSelector(getSelectedPdp, 'formInfo')
+export const getPdpContentsLoaded = createGetSelector(getSelectedPdp, 'contentsLoaded')
+
+export const getProductTitle = createGetSelector(getSelectedProduct, 'title')
+export const getProductPrice = createGetSelector(getSelectedProduct, 'price')
+export const getProductDescription = createGetSelector(getSelectedProduct, 'description')
+export const getProductCarouselItems = createGetSelector(getSelectedProduct, 'carouselItems')

--- a/app/containers/plp/container.js
+++ b/app/containers/plp/container.js
@@ -82,14 +82,14 @@ const PLP = ({hasProducts, contentsLoaded, noResultsText, numItems, title, produ
 
 
 PLP.propTypes = {
-    contentsLoaded: PropTypes.bool,
-    hasProducts: PropTypes.bool,
-    noResultsText: PropTypes.string,
-    numItems: PropTypes.string,
     /**
      * Product data from state (Catalog -> Products), filtered by the productUrls in the Plp state object
      */
     products: PropTypes.array.isRequired,
+    contentsLoaded: PropTypes.bool,
+    hasProducts: PropTypes.bool,
+    noResultsText: PropTypes.string,
+    numItems: PropTypes.string,
     title: PropTypes.string
 }
 

--- a/app/containers/plp/container.js
+++ b/app/containers/plp/container.js
@@ -33,15 +33,7 @@ const renderNoResults = (bodyText) => {
     )
 }
 
-const PLP = ({plp, products}) => {
-    const {
-        hasProducts,
-        contentsLoaded,
-        noResultsText,
-        numItems,
-        title
-    } = plp
-
+const PLP = ({hasProducts, contentsLoaded, noResultsText, numItems, title, products}) => {
     return (
         <div className="t-plp">
             <div className="u-flexbox u-align-bottom">
@@ -90,19 +82,24 @@ const PLP = ({plp, products}) => {
 
 
 PLP.propTypes = {
-    /**
-     * The Immutable.js PLP state object
-     */
-    plp: PropTypes.object.isRequired,
+    contentsLoaded: PropTypes.bool,
+    hasProducts: PropTypes.bool,
+    noResultsText: PropTypes.string,
+    numItems: PropTypes.string,
     /**
      * Product data from state (Catalog -> Products), filtered by the productUrls in the Plp state object
      */
-    products: PropTypes.array.isRequired
+    products: PropTypes.array.isRequired,
+    title: PropTypes.string
 }
 
 const mapStateToProps = createStructuredSelector({
-    products: selectorToJS(selectors.getPlpProducts),
-    plp: selectorToJS(selectors.getSelectedPlp)
+    hasProducts: selectors.getHasProducts,
+    contentsLoaded: selectors.getPlpContentsLoaded,
+    noResultsText: selectors.getNoResultsText,
+    numItems: selectors.getNumItems,
+    title: selectors.getPlpTitle,
+    products: selectorToJS(selectors.getPlpProducts)
 })
 
 export default connect(

--- a/app/containers/plp/selectors.js
+++ b/app/containers/plp/selectors.js
@@ -22,6 +22,11 @@ export const getSelectedPlp = createSelector(
 )
 
 export const getProductUrls = createGetSelector(getSelectedPlp, 'productUrls')
+export const getHasProducts = createGetSelector(getSelectedPlp, 'hasProducts')
+export const getPlpContentsLoaded = createGetSelector(getSelectedPlp, 'contentsLoaded')
+export const getNoResultsText = createGetSelector(getSelectedPlp, 'getNoResultsText')
+export const getNumItems = createGetSelector(getSelectedPlp, 'numItems')
+export const getPlpTitle = createGetSelector(getSelectedPlp, 'title')
 
 export const getPlpProducts = createSelector(
     globalSelectors.getCatalogProducts,

--- a/app/containers/plp/selectors.js
+++ b/app/containers/plp/selectors.js
@@ -1,4 +1,5 @@
 import {createSelector} from 'reselect'
+import {createGetSelector} from '../../utils/selector-utils'
 import * as globalSelectors from '../../store/selectors'
 import {getSelectorFromState} from '../../utils/router-utils'
 
@@ -20,10 +21,7 @@ export const getSelectedPlp = createSelector(
     (plp, plpSelector) => plp.get(plpSelector)
 )
 
-export const getProductUrls = createSelector(
-    getSelectedPlp,
-    (plp) => plp.get('productUrls')
-)
+export const getProductUrls = createGetSelector(getSelectedPlp, 'productUrls')
 
 export const getPlpProducts = createSelector(
     globalSelectors.getCatalogProducts,

--- a/app/utils/selector-utils.js
+++ b/app/utils/selector-utils.js
@@ -12,3 +12,8 @@ export const selectorToJS = (selector) => createImmutableComparingSelector(
 )
 
 export const createToJSSelector = (...args) => selectorToJS(createSelector(...args))
+
+export const createGetSelector = (selector, key) => createSelector(
+    selector,
+    (obj) => obj.get(key)
+)


### PR DESCRIPTION
This PR breaks up access to the store contents into individual selectors for each member of the template (and catalog) objects. This is in preparation for both a) rearranging the store, and b) connecting the store closer to where the values are used.

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1032

## Changes
- Write more specific selectors
- Use them in `mapStateToProps` in lieu of the more general selectors
