### PR TITLE
Connect further down in Header, Footer, Home, and PDP

### DIFF
--- a/app/containers/footer/container.js
+++ b/app/containers/footer/container.js
@@ -17,30 +17,16 @@ const social = [
     ['http://www.youtube.com/#TODO', 'static/svg/youtube.svg', 'Youtube'],
 ]
 
-class Footer extends React.Component {
-    constructor(props) {
-        super(props)
+const Footer = ({footer, submitNewsletter}) => {
+    const {navigation, newsletter} = footer
 
-        this.onSubmitNewsletter = this.onSubmitNewsletter.bind(this)
-    }
-
-    onSubmitNewsletter(data) {
-        const {method, action} = this.props.footer.newsletter
-        this.props.submitNewsletter(method, action, data)
-    }
-
-    render() {
-        const {footer} = this.props
-        const {navigation, newsletter} = footer
-
-        return (
-            <footer className="t-footer">
-                <FooterNewsletterSubscription newsletter={newsletter} onSubmit={this.onSubmitNewsletter} />
-                <FooterSocialIcons social={social} />
-                <FooterNavigation navigation={navigation} />
-            </footer>
-        )
-    }
+    return (
+        <footer className="t-footer">
+            <FooterNewsletterSubscription newsletter={newsletter} onSubmit={submitNewsletter} />
+            <FooterSocialIcons social={social} />
+            <FooterNavigation navigation={navigation} />
+        </footer>
+    )
 }
 
 Footer.propTypes = {

--- a/app/containers/footer/container.js
+++ b/app/containers/footer/container.js
@@ -4,18 +4,11 @@ import FooterNewsletterSubscription from './partials/footer-newsletter-subscript
 import FooterSocialIcons from './partials/footer-social-icons'
 import FooterNavigation from './partials/footer-navigation'
 
-const social = [
-    ['http://www.facebook.com/#TODO', 'static/svg/facebook.svg', 'Facebook'],
-    ['http://www.twitter.com/#TODO', 'static/svg/twitter.svg', 'Twitter'],
-    ['http://plus.google.com/#TODO', 'static/svg/googleplus.svg', 'Google+'],
-    ['http://www.youtube.com/#TODO', 'static/svg/youtube.svg', 'Youtube'],
-]
-
 const Footer = () => {
     return (
         <footer className="t-footer">
             <FooterNewsletterSubscription />
-            <FooterSocialIcons social={social} />
+            <FooterSocialIcons />
             <FooterNavigation />
         </footer>
     )

--- a/app/containers/footer/container.js
+++ b/app/containers/footer/container.js
@@ -1,10 +1,4 @@
-import React, {PropTypes} from 'react'
-import {connect} from 'react-redux'
-import {createStructuredSelector} from 'reselect'
-import {selectorToJS} from '../../utils/selector-utils'
-
-import * as actions from './actions'
-import * as selectors from './selectors'
+import React from 'react'
 
 import FooterNewsletterSubscription from './partials/footer-newsletter-subscription'
 import FooterSocialIcons from './partials/footer-social-icons'
@@ -17,39 +11,14 @@ const social = [
     ['http://www.youtube.com/#TODO', 'static/svg/youtube.svg', 'Youtube'],
 ]
 
-const Footer = ({footer, submitNewsletter}) => {
-    const {navigation, newsletter} = footer
-
+const Footer = () => {
     return (
         <footer className="t-footer">
-            <FooterNewsletterSubscription newsletter={newsletter} onSubmit={submitNewsletter} />
+            <FooterNewsletterSubscription />
             <FooterSocialIcons social={social} />
-            <FooterNavigation navigation={navigation} />
+            <FooterNavigation />
         </footer>
     )
 }
 
-Footer.propTypes = {
-    /**
-     * Slice into the global app state
-     */
-    footer: PropTypes.object,
-    /**
-     * Submit the newsletter subscription form to the backend
-     */
-    submitNewsletter: PropTypes.func
-}
-
-
-const mapStateToProps = createStructuredSelector({
-    footer: selectorToJS(selectors.getFooter)
-})
-
-const mapDispatchToProps = {
-    submitNewsletter: actions.signUpToNewsletter
-}
-
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps
-)(Footer)
+export default Footer

--- a/app/containers/footer/partials/footer-navigation.jsx
+++ b/app/containers/footer/partials/footer-navigation.jsx
@@ -1,4 +1,8 @@
 import React, {PropTypes} from 'react'
+import {createStructuredSelector} from 'reselect'
+import * as selectors from '../selectors'
+import {selectorToJS} from '../../../utils/selector-utils'
+import {connect} from 'react-redux'
 
 import Divider from 'progressive-web-sdk/dist/components/divider'
 import ListTile from 'progressive-web-sdk/dist/components/list-tile'
@@ -29,4 +33,8 @@ FooterNavigation.propTypes = {
     navigation: PropTypes.array
 }
 
-export default FooterNavigation
+const mapStateToProps = createStructuredSelector({
+    navigation: selectorToJS(selectors.getNavigation)
+})
+
+export default connect(mapStateToProps)(FooterNavigation)

--- a/app/containers/footer/partials/footer-newsletter-subscription.jsx
+++ b/app/containers/footer/partials/footer-newsletter-subscription.jsx
@@ -1,19 +1,36 @@
 import React, {PropTypes} from 'react'
+import {createStructuredSelector} from 'reselect'
+import * as selectors from '../selectors'
+import {selectorToJS} from '../../../utils/selector-utils'
 
 import NewsletterForm from './newsletter-form'
 
-const FooterNewsletterSubscription = ({newsletter, onSubmit}) => {
-    return (
-        <div className="t-footer__newsletter u-padding-md u-padding-top-lg u-padding-bottom-lg">
-            <div>
-                <h2 className="u-h2 u-margin-bottom-md">
-                    Subscribe to Merlin&#39;s Newsletter
-                </h2>
+class FooterNewsletterSubscription extends React.Component {
+    constructor(props) {
+        super(props)
 
-                <NewsletterForm disabled={!newsletter} onSubmit={onSubmit} />
+        this.onSubmitNewsletter = this.onSubmitNewsletter.bind(this)
+    }
+
+    onSubmitNewsletter(data) {
+        const {method, action} = this.props.newsletter
+        this.props.onSubmit(action, method, data)
+    }
+
+    render() {
+        const {newsletter, onSubmit} = this.props
+        return (
+            <div className="t-footer__newsletter u-padding-md u-padding-top-lg u-padding-bottom-lg">
+                <div>
+                    <h2 className="u-h2 u-margin-bottom-md">
+                        Subscribe to Merlin&#39;s Newsletter
+                    </h2>
+
+                    <NewsletterForm disabled={!newsletter} onSubmit={this.onSubmitNewsletter} />
+                </div>
             </div>
-        </div>
-    )
+        )
+    }
 }
 
 FooterNewsletterSubscription.propTypes = {

--- a/app/containers/footer/partials/footer-newsletter-subscription.jsx
+++ b/app/containers/footer/partials/footer-newsletter-subscription.jsx
@@ -1,7 +1,9 @@
 import React, {PropTypes} from 'react'
 import {createStructuredSelector} from 'reselect'
 import * as selectors from '../selectors'
+import * as actions from '../actions'
 import {selectorToJS} from '../../../utils/selector-utils'
+import {connect} from 'react-redux'
 
 import NewsletterForm from './newsletter-form'
 
@@ -38,4 +40,15 @@ FooterNewsletterSubscription.propTypes = {
     onSubmit: PropTypes.func
 }
 
-export default FooterNewsletterSubscription
+const mapStateToProps = createStructuredSelector({
+    newsletter: selectors.getNewsletter
+})
+
+const mapDispatchToProps = {
+    onSubmit: actions.signUpToNewsletter
+}
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(FooterNewsletterSubscription)

--- a/app/containers/footer/partials/footer-newsletter-subscription.jsx
+++ b/app/containers/footer/partials/footer-newsletter-subscription.jsx
@@ -2,7 +2,6 @@ import React, {PropTypes} from 'react'
 import {createStructuredSelector} from 'reselect'
 import * as selectors from '../selectors'
 import * as actions from '../actions'
-import {selectorToJS} from '../../../utils/selector-utils'
 import {connect} from 'react-redux'
 
 import NewsletterForm from './newsletter-form'
@@ -20,7 +19,7 @@ class FooterNewsletterSubscription extends React.Component {
     }
 
     render() {
-        const {newsletter, onSubmit} = this.props
+        const {newsletter} = this.props
         return (
             <div className="t-footer__newsletter u-padding-md u-padding-top-lg u-padding-bottom-lg">
                 <div>

--- a/app/containers/footer/partials/footer-social-icons.jsx
+++ b/app/containers/footer/partials/footer-social-icons.jsx
@@ -1,7 +1,14 @@
-import React, {PropTypes} from 'react'
+import React from 'react'
 import {getAssetUrl} from 'progressive-web-sdk/dist/asset-utils'
 
-const FooterSocialIcons = ({social}) => {
+const social = [
+    ['http://www.facebook.com/#TODO', 'static/svg/facebook.svg', 'Facebook'],
+    ['http://www.twitter.com/#TODO', 'static/svg/twitter.svg', 'Twitter'],
+    ['http://plus.google.com/#TODO', 'static/svg/googleplus.svg', 'Google+'],
+    ['http://www.youtube.com/#TODO', 'static/svg/youtube.svg', 'Youtube'],
+]
+
+const FooterSocialIcons = () => {
     return (
         <div className="t-footer__social u-padding-md">
             <div className="u-flexbox u-justify-center u-padding-md">
@@ -13,10 +20,6 @@ const FooterSocialIcons = ({social}) => {
             </div>
         </div>
     )
-}
-
-FooterSocialIcons.propTypes = {
-    social: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string))
 }
 
 export default FooterSocialIcons

--- a/app/containers/footer/selectors.js
+++ b/app/containers/footer/selectors.js
@@ -1,6 +1,11 @@
 import {createSelector} from 'reselect'
+import {createGetSelector} from '../../utils/selector-utils'
 import * as globalSelectors from '../../store/selectors'
+
 export const getFooter = createSelector(
     globalSelectors.getUi,
     ({footer}) => footer
 )
+
+export const getNewsletter = createGetSelector(getFooter, 'newsletter')
+export const getNavigation = createGetSelector(getFooter, 'navigation')

--- a/app/containers/header/container.js
+++ b/app/containers/header/container.js
@@ -44,7 +44,7 @@ class Header extends React.Component {
     }
 
     render() {
-        const {onMenuClick, onMiniCartClick, isCollapsed, itemCount} = this.props
+        const {onMenuClick, onMiniCartClick, isCollapsed} = this.props
 
         const innerButtonClassName = classnames('t-header__inner-button', 'u-padding-0', {
             't--hide-label': isCollapsed
@@ -58,7 +58,7 @@ class Header extends React.Component {
                         <div className="t-header__placeholder" />
                         <HeaderTitle isCollapsed={isCollapsed} />
                         <StoresAction innerButtonClassName={innerButtonClassName} />
-                        <CartAction innerButtonClassName={innerButtonClassName} onClick={onMiniCartClick} itemCount={itemCount} />
+                        <CartAction innerButtonClassName={innerButtonClassName} onClick={onMiniCartClick} />
                     </HeaderBar>
                 </div>
             </header>
@@ -68,16 +68,14 @@ class Header extends React.Component {
 
 Header.propTypes = {
     isCollapsed: PropTypes.bool,
-    itemCount: PropTypes.number,
     toggleHeader: PropTypes.func,
 
     onMenuClick: PropTypes.func,
-    onMiniCartClick: PropTypes.func,
+    onMiniCartClick: PropTypes.func
 }
 
 const mapStateToProps = createStructuredSelector({
-    isCollapsed: selectors.getIsCollapsed,
-    itemCount: selectors.getItemCount
+    isCollapsed: selectors.getIsCollapsed
 })
 
 const mapDispatchToProps = {

--- a/app/containers/header/partials/cart-action.jsx
+++ b/app/containers/header/partials/cart-action.jsx
@@ -1,9 +1,12 @@
 import React, {PropTypes} from 'react'
+import {connect} from 'react-redux'
+import {createStructuredSelector} from 'reselect'
 
 import Badge from 'progressive-web-sdk/dist/components/badge'
 import Button from 'progressive-web-sdk/dist/components/button'
 import IconLabel from 'progressive-web-sdk/dist/components/icon-label'
 import {HeaderBarActions} from 'progressive-web-sdk/dist/components/header-bar'
+import * as selectors from '../selectors'
 
 const CartItemCounterBadge = ({itemCount}) => {
     // `undefined` is not greater than 0
@@ -39,4 +42,8 @@ CartAction.propTypes = {
     onClick: PropTypes.func
 }
 
-export default CartAction
+const mapStateToProps = createStructuredSelector({
+    itemCount: selectors.getItemCount
+})
+
+export default connect(mapStateToProps)(CartAction)

--- a/app/containers/home/container.js
+++ b/app/containers/home/container.js
@@ -1,32 +1,15 @@
-import React, {PropTypes} from 'react'
-import {connect} from 'react-redux'
-import {createStructuredSelector} from 'reselect'
-import {selectorToJS} from '../../utils/selector-utils'
+import React from 'react'
 
-import * as selectors from './selectors'
 import HomeCarousel from './partials/home-carousel'
 import HomeCategories from './partials/home-categories'
 
-const Home = ({banners, categories}) => {
-
+const Home = () => {
     return (
         <div className="t-home__container">
-            <HomeCarousel banners={banners} />
-            <HomeCategories categories={categories} />
+            <HomeCarousel />
+            <HomeCategories />
         </div>
     )
 }
 
-Home.propTypes = {
-    banners: PropTypes.array.isRequired,
-    categories: PropTypes.array.isRequired
-}
-
-const mapStateToProps = createStructuredSelector({
-    banners: selectorToJS(selectors.getHomeBanners),
-    categories: selectorToJS(selectors.getHomeCategories)
-})
-
-export default connect(
-    mapStateToProps
-)(Home)
+export default Home

--- a/app/containers/home/partials/home-carousel.jsx
+++ b/app/containers/home/partials/home-carousel.jsx
@@ -1,10 +1,14 @@
 import React, {PropTypes} from 'react'
+import {connect} from 'react-redux'
+import {createStructuredSelector} from 'reselect'
+import {selectorToJS} from '../../../utils/selector-utils'
 import {getAssetUrl} from 'progressive-web-sdk/dist/asset-utils'
 
 import Carousel from 'progressive-web-sdk/dist/components/carousel'
 import CarouselItem from 'progressive-web-sdk/dist/components/carousel/carousel-item'
 import Image from 'progressive-web-sdk/dist/components/image'
 import SkeletonBlock from 'progressive-web-sdk/dist/components/skeleton-block'
+import * as selectors from '../selectors'
 
 // The ratio of the banner image width:height is 1:.75. Since the banner will be
 // width=100%, we can use 75vw to predict the banner height.
@@ -16,11 +20,11 @@ const HomeCarousel = ({banners}) => {
         <div className="t-home__carousel">
             {banners.length > 0 ?
                 <Carousel allowLooping={true} className="pw--hide-controls">
-                    {banners.map(({src, href, alt}, key) => { // TODO: fix this when we put mobile assets on desktop
+                    {banners.map(({src, href, alt}, index) => { // TODO: fix this when we put mobile assets on desktop
                         return (
-                            <CarouselItem href={href} key={key}>
+                            <CarouselItem href={href} key={index}>
                                 <Image
-                                    src={getAssetUrl(`static/img/homepage_carousel/${key}.png`)}
+                                    src={getAssetUrl(`static/img/homepage_carousel/${index}.png`)}
                                     alt={alt}
                                     className="u-block"
                                     hidePlaceholder={true}
@@ -40,10 +44,11 @@ const HomeCarousel = ({banners}) => {
 }
 
 HomeCarousel.propTypes = {
-    banners: PropTypes.oneOfType([
-        PropTypes.bool,
-        PropTypes.array
-    ]).isRequired,
+    banners: PropTypes.array
 }
 
-export default HomeCarousel
+const mapStateToProps = createStructuredSelector({
+    banners: selectorToJS(selectors.getHomeBanners)
+})
+
+export default connect(mapStateToProps)(HomeCarousel)

--- a/app/containers/home/partials/home-categories.jsx
+++ b/app/containers/home/partials/home-categories.jsx
@@ -12,8 +12,11 @@ import SkeletonBlock from 'progressive-web-sdk/dist/components/skeleton-block'
 import SkeletonText from 'progressive-web-sdk/dist/components/skeleton-text'
 import * as selectors from '../selectors'
 
-const getImage = (alt) => {
-    return alt ? (
+const CategoryImage = ({alt}) => {
+    if (!alt) {
+        return (<SkeletonBlock height="60px" width="60px" />)
+    }
+    return (
         <Image
             src={getAssetUrl(`static/img/categories/${alt.trim().replace(/\s+/g, '-')
             .toLowerCase()}@2x.png`)}
@@ -21,13 +24,14 @@ const getImage = (alt) => {
             height="60px"
             width="60px"
         />
-    ) : (
-        <SkeletonBlock height="60px" width="60px" />
     )
 }
 
-const renderCategory = (category, key) => {
-    const {href, text} = category
+CategoryImage.propTypes = {
+    alt: PropTypes.string
+}
+
+const HomeCategory = ({category: {href, text}}) => {
     const categoryClasses = classNames('t-home__category-section', {
         'u-text-all-caps': !!text
     })
@@ -36,10 +40,9 @@ const renderCategory = (category, key) => {
         <ListTile
             className={categoryClasses}
             href={href}
-            startAction={getImage(text)}
+            startAction={<CategoryImage alt={text} />}
             endAction={<Icon name="chevron-right" />}
             includeEndActionInPrimary={true}
-            key={key}
         >
             <div className="u-h2 t-home__category-text u-text-lighter">SHOP</div>
 
@@ -56,18 +59,25 @@ const renderCategory = (category, key) => {
     )
 }
 
+HomeCategory.propTypes = {
+    category: PropTypes.shape({
+        href: PropTypes.string,
+        text: PropTypes.string
+    })
+}
+
 const HomeCategories = ({categories}) => {
     return (
         <div className="t-home__category u-padding-start u-padding-end u-padding-bottom-md">
             <div className="u-card">
-                {categories.map(renderCategory)}
+                {categories.map((category, index) => <HomeCategory category={category} key={index} />)}
             </div>
         </div>
     )
 }
 
 HomeCategories.propTypes = {
-    categories: PropTypes.array.isRequired,
+    categories: PropTypes.array.isRequired
 }
 
 const mapStateToProps = createStructuredSelector({

--- a/app/containers/home/partials/home-categories.jsx
+++ b/app/containers/home/partials/home-categories.jsx
@@ -1,5 +1,8 @@
 import React, {PropTypes} from 'react'
 import classNames from 'classnames'
+import {connect} from 'react-redux'
+import {createStructuredSelector} from 'reselect'
+import {selectorToJS} from '../../../utils/selector-utils'
 import {getAssetUrl} from 'progressive-web-sdk/dist/asset-utils'
 
 import {Icon} from 'progressive-web-sdk/dist/components/icon'
@@ -7,6 +10,7 @@ import Image from 'progressive-web-sdk/dist/components/image'
 import ListTile from 'progressive-web-sdk/dist/components/list-tile'
 import SkeletonBlock from 'progressive-web-sdk/dist/components/skeleton-block'
 import SkeletonText from 'progressive-web-sdk/dist/components/skeleton-text'
+import * as selectors from '../selectors'
 
 const getImage = (alt) => {
     return alt ? (
@@ -66,4 +70,8 @@ HomeCategories.propTypes = {
     categories: PropTypes.array.isRequired,
 }
 
-export default HomeCategories
+const mapStateToProps = createStructuredSelector({
+    categories: selectorToJS(selectors.getHomeCategories)
+})
+
+export default connect(mapStateToProps)(HomeCategories)

--- a/app/containers/home/reducer.js
+++ b/app/containers/home/reducer.js
@@ -9,7 +9,7 @@ import Home from './container'
 const CATEGORY_PLACEHOLDER_COUNT = 6
 
 const initialState = fromJS({
-    categories: new Array(CATEGORY_PLACEHOLDER_COUNT).fill(''),
+    categories: new Array(CATEGORY_PLACEHOLDER_COUNT).fill({}),
     banners: []
 })
 

--- a/app/containers/pdp/container.js
+++ b/app/containers/pdp/container.js
@@ -13,13 +13,9 @@ import * as pdpActions from './actions'
 import * as selectors from './selectors'
 
 const PDP = ({
-    setQuantity,
-    addToCart,
     closeItemAddedModal,
-    itemQuantity,
     quantityAdded,
     itemAddedModalOpen,
-    formInfo,
     contentsLoaded,
     title,
     price,
@@ -30,14 +26,7 @@ const PDP = ({
             <PDPHeading />
             <PDPCarousel />
             <PDPDescription />
-
-            <PDPAddToCart
-                formInfo={formInfo}
-                quantity={itemQuantity}
-                setQuantity={setQuantity}
-                onSubmit={addToCart}
-                disabled={!contentsLoaded}
-                />
+            <PDPAddToCart />
 
             {contentsLoaded &&
                 <PDPItemAddedModal
@@ -53,23 +42,12 @@ const PDP = ({
 
 PDP.propTypes = {
     /**
-     * Function to submit the add-to-cart form
-     */
-    addToCart: PropTypes.func.isRequired,
-    /**
      * Callback when the added-to-cart modal closes
      */
     closeItemAddedModal: PropTypes.func.isRequired,
-    /**
-     * Function to update the item quantity when user changes it
-     */
-    setQuantity: PropTypes.func.isRequired,
     carouselItems: PropTypes.array,
     contentsLoaded: PropTypes.bool,
-    description: PropTypes.string,
-    formInfo: PropTypes.object,
     itemAddedModalOpen: PropTypes.bool,
-    itemQuantity: PropTypes.number,
     price: PropTypes.string,
     quantityAdded: PropTypes.number,
     title: PropTypes.string
@@ -78,18 +56,13 @@ PDP.propTypes = {
 export const mapStateToProps = createStructuredSelector({
     title: selectors.getProductTitle,
     price: selectors.getProductPrice,
-    description: selectors.getProductDescription,
     carouselItems: selectorToJS(selectors.getProductCarouselItems),
-    itemQuantity: selectors.getItemQuantity,
     quantityAdded: selectors.getQuantityAdded,
     itemAddedModalOpen: selectors.getItemAddedModalOpen,
-    formInfo: selectorToJS(selectors.getFormInfo),
     contentsLoaded: selectors.getPdpContentsLoaded
 })
 
 const mapDispatchToProps = {
-    setQuantity: pdpActions.setItemQuantity,
-    addToCart: stripEvent(pdpActions.submitCartForm),
     closeItemAddedModal: stripEvent(pdpActions.closeItemAddedModal)
 }
 

--- a/app/containers/pdp/container.js
+++ b/app/containers/pdp/container.js
@@ -1,72 +1,21 @@
-import React, {PropTypes} from 'react'
-import {connect} from 'react-redux'
-import {createStructuredSelector} from 'reselect'
-import {selectorToJS} from '../../utils/selector-utils'
+import React from 'react'
 
 import PDPHeading from './partials/pdp-heading'
 import PDPCarousel from './partials/pdp-carousel'
 import PDPDescription from './partials/pdp-description'
 import PDPAddToCart from './partials/pdp-add-to-cart'
 import PDPItemAddedModal from './partials/pdp-item-added-modal'
-import {stripEvent} from '../../utils/utils'
-import * as pdpActions from './actions'
-import * as selectors from './selectors'
 
-const PDP = ({
-    closeItemAddedModal,
-    quantityAdded,
-    itemAddedModalOpen,
-    contentsLoaded,
-    title,
-    price,
-    carouselItems
-}) => {
+const PDP = () => {
     return (
         <div className="t-pdp">
             <PDPHeading />
             <PDPCarousel />
             <PDPDescription />
             <PDPAddToCart />
-
-            {contentsLoaded &&
-                <PDPItemAddedModal
-                    open={itemAddedModalOpen}
-                    onDismiss={closeItemAddedModal}
-                    product={{title, price, carouselItems}}
-                    quantity={quantityAdded}
-                    />
-                }
+            <PDPItemAddedModal />
         </div>
     )
 }
 
-PDP.propTypes = {
-    /**
-     * Callback when the added-to-cart modal closes
-     */
-    closeItemAddedModal: PropTypes.func.isRequired,
-    carouselItems: PropTypes.array,
-    contentsLoaded: PropTypes.bool,
-    itemAddedModalOpen: PropTypes.bool,
-    price: PropTypes.string,
-    quantityAdded: PropTypes.number,
-    title: PropTypes.string
-}
-
-export const mapStateToProps = createStructuredSelector({
-    title: selectors.getProductTitle,
-    price: selectors.getProductPrice,
-    carouselItems: selectorToJS(selectors.getProductCarouselItems),
-    quantityAdded: selectors.getQuantityAdded,
-    itemAddedModalOpen: selectors.getItemAddedModalOpen,
-    contentsLoaded: selectors.getPdpContentsLoaded
-})
-
-const mapDispatchToProps = {
-    closeItemAddedModal: stripEvent(pdpActions.closeItemAddedModal)
-}
-
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps
-)(PDP)
+export default PDP

--- a/app/containers/pdp/container.js
+++ b/app/containers/pdp/container.js
@@ -28,9 +28,7 @@ const PDP = ({
     return (
         <div className="t-pdp">
             <PDPHeading />
-
-            <PDPCarousel items={carouselItems} contentsLoaded={contentsLoaded} />
-
+            <PDPCarousel />
             <PDPDescription />
 
             <PDPAddToCart

--- a/app/containers/pdp/container.js
+++ b/app/containers/pdp/container.js
@@ -23,7 +23,6 @@ const PDP = ({
     contentsLoaded,
     title,
     price,
-    description,
     carouselItems
 }) => {
     return (
@@ -32,7 +31,7 @@ const PDP = ({
 
             <PDPCarousel items={carouselItems} contentsLoaded={contentsLoaded} />
 
-            <PDPDescription description={description} />
+            <PDPDescription />
 
             <PDPAddToCart
                 formInfo={formInfo}
@@ -46,7 +45,7 @@ const PDP = ({
                 <PDPItemAddedModal
                     open={itemAddedModalOpen}
                     onDismiss={closeItemAddedModal}
-                    product={{title, price, description, carouselItems}}
+                    product={{title, price, carouselItems}}
                     quantity={quantityAdded}
                     />
                 }

--- a/app/containers/pdp/container.js
+++ b/app/containers/pdp/container.js
@@ -28,7 +28,7 @@ const PDP = ({
 }) => {
     return (
         <div className="t-pdp">
-            <PDPHeading title={title} price={price} />
+            <PDPHeading />
 
             <PDPCarousel items={carouselItems} contentsLoaded={contentsLoaded} />
 

--- a/app/containers/pdp/partials/pdp-add-to-cart.jsx
+++ b/app/containers/pdp/partials/pdp-add-to-cart.jsx
@@ -1,4 +1,10 @@
 import React, {PropTypes} from 'react'
+import {connect} from 'react-redux'
+import {createStructuredSelector} from 'reselect'
+import {invertSelector} from '../../../utils/selector-utils'
+import * as selectors from '../selectors'
+import * as actions from '../actions'
+
 import Button from 'progressive-web-sdk/dist/components/button'
 import {Icon} from 'progressive-web-sdk/dist/components/icon'
 import Stepper from 'progressive-web-sdk/dist/components/stepper'
@@ -53,4 +59,17 @@ PDPAddToCart.propTypes = {
     disabled: PropTypes.bool
 }
 
-export default PDPAddToCart
+const mapStateToProps = createStructuredSelector({
+    quantity: selectors.getItemQuantity,
+    disabled: invertSelector(selectors.getPdpContentsLoaded)
+})
+
+const mapDispatchToProps = {
+    setQuantity: actions.setItemQuantity,
+    onSubmit: actions.submitCartForm
+}
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(PDPAddToCart)

--- a/app/containers/pdp/partials/pdp-carousel.jsx
+++ b/app/containers/pdp/partials/pdp-carousel.jsx
@@ -1,4 +1,8 @@
 import React, {PropTypes} from 'react'
+import {connect} from 'react-redux'
+import {createStructuredSelector} from 'reselect'
+import {selectorToJS} from '../../../utils/selector-utils'
+import * as selectors from '../selectors'
 
 import Carousel from 'progressive-web-sdk/dist/components/carousel'
 import CarouselItem from 'progressive-web-sdk/dist/components/carousel/carousel-item'
@@ -68,4 +72,9 @@ PDPCarousel.propTypes = {
     }))
 }
 
-export default PDPCarousel
+const mapStateToProps = createStructuredSelector({
+    contentsLoaded: selectors.getPdpContentsLoaded,
+    items: selectorToJS(selectors.getProductCarouselItems)
+})
+
+export default connect(mapStateToProps)(PDPCarousel)

--- a/app/containers/pdp/partials/pdp-carousel.test.js
+++ b/app/containers/pdp/partials/pdp-carousel.test.js
@@ -1,11 +1,13 @@
 import React from 'react'
-import PDPCarousel from './pdp-carousel'
+import ConnectedPDPCarousel from './pdp-carousel'
 import {mount, shallow} from 'enzyme'
 
 import Carousel from 'progressive-web-sdk/dist/components/carousel'
 import CarouselItem from 'progressive-web-sdk/dist/components/carousel/carousel-item'
 import Image from 'progressive-web-sdk/dist/components/image'
 import SkeletonBlock from 'progressive-web-sdk/dist/components/skeleton-block'
+
+const PDPCarousel = ConnectedPDPCarousel.WrappedComponent
 
 /* eslint-disable newline-per-chained-call */
 

--- a/app/containers/pdp/partials/pdp-description.jsx
+++ b/app/containers/pdp/partials/pdp-description.jsx
@@ -1,4 +1,8 @@
 import React, {PropTypes} from 'react'
+import {connect} from 'react-redux'
+import {createStructuredSelector} from 'reselect'
+import * as selectors from '../selectors'
+
 import {Accordion, AccordionItem} from 'progressive-web-sdk/dist/components/accordion'
 
 const PDPDescription = ({description}) => (
@@ -13,4 +17,8 @@ PDPDescription.propTypes = {
     description: PropTypes.string
 }
 
-export default PDPDescription
+const mapStateToProps = createStructuredSelector({
+    description: selectors.getProductDescription
+})
+
+export default connect(mapStateToProps)(PDPDescription)

--- a/app/containers/pdp/partials/pdp-description.test.js
+++ b/app/containers/pdp/partials/pdp-description.test.js
@@ -1,7 +1,9 @@
 import React from 'react'
-import PDPDescription from './pdp-description'
+import ConnectedPDPDescription from './pdp-description'
 import {mount, shallow} from 'enzyme'
 import {Accordion, AccordionItem} from 'progressive-web-sdk/dist/components/accordion'
+
+const PDPDescription = ConnectedPDPDescription.WrappedComponent
 
 /* eslint-disable newline-per-chained-call */
 

--- a/app/containers/pdp/partials/pdp-heading.jsx
+++ b/app/containers/pdp/partials/pdp-heading.jsx
@@ -1,4 +1,8 @@
 import React, {PropTypes} from 'react'
+import {connect} from 'react-redux'
+import {createStructuredSelector} from 'reselect'
+import * as selectors from '../selectors'
+
 import SkeletonBlock from 'progressive-web-sdk/dist/components/skeleton-block'
 
 const PDPHeading = ({title, price}) => (
@@ -22,4 +26,9 @@ PDPHeading.propTypes = {
     title: PropTypes.string
 }
 
-export default PDPHeading
+const mapStateToProps = createStructuredSelector({
+    title: selectors.getProductTitle,
+    price: selectors.getProductPrice
+})
+
+export default connect(mapStateToProps)(PDPHeading)

--- a/app/containers/pdp/partials/pdp-heading.test.js
+++ b/app/containers/pdp/partials/pdp-heading.test.js
@@ -1,6 +1,8 @@
 import React from 'react'
-import PDPHeading from './pdp-heading'
+import ConnectedPDPHeading from './pdp-heading'
 import {mount, shallow} from 'enzyme'
+
+const PDPHeading = ConnectedPDPHeading.WrappedComponent
 
 test('renders without errors', () => {
     const wrapper = mount(<PDPHeading />)

--- a/app/containers/pdp/partials/pdp-item-added-modal.jsx
+++ b/app/containers/pdp/partials/pdp-item-added-modal.jsx
@@ -1,12 +1,19 @@
 import React, {PropTypes} from 'react'
+import {connect} from 'react-redux'
+import {createStructuredSelector} from 'reselect'
+import * as selectors from '../selectors'
+import * as actions from '../actions'
+import {stripEvent} from '../../../utils/utils'
 
 import Button from 'progressive-web-sdk/dist/components/button'
 import {Icon} from 'progressive-web-sdk/dist/components/icon'
 import ProductItem from '../../../components/product-item'
 import Sheet from 'progressive-web-sdk/dist/components/sheet'
 
-const PDPItemAddedModal = ({open, onDismiss, quantity, product: {title, price, carouselItems}}) => (
+const PDPItemAddedModal = ({open, onDismiss, quantity, title, price, productImage}) => (
     <Sheet open={open} onDismiss={onDismiss} effect="slide-bottom" className="t-plp__item-added-modal" coverage="50%">
+
+        {/* Modal header */}
         <div className="u-flex-none u-border-bottom">
             <div className="u-flexbox u-align-center">
                 <h1 className="u-flex u-padding-lg u-h4 u-text-uppercase">
@@ -22,10 +29,11 @@ const PDPItemAddedModal = ({open, onDismiss, quantity, product: {title, price, c
         </div>
 
         <div className="u-flexbox u-column u-flex u-padding-md">
+            {/* Modal product information */}
             <div className="u-flex u-margin-bottom-md">
                 <ProductItem
                     title={<h2 className="c-h4">{title}</h2>}
-                    image={<img role="presentation" src={carouselItems[0].img} alt="" width="60px" />}
+                    image={<img role="presentation" src={productImage} alt="" width="60px" />}
                 >
                     <div className="u-flexbox u-justify-between u-padding-top-sm">
                         <p>Qty: {quantity}</p>
@@ -34,6 +42,7 @@ const PDPItemAddedModal = ({open, onDismiss, quantity, product: {title, price, c
                 </ProductItem>
             </div>
 
+            {/* Buttons */}
             <div className="u-flex-none">
                 <Button
                     href="#"
@@ -52,9 +61,26 @@ const PDPItemAddedModal = ({open, onDismiss, quantity, product: {title, price, c
 
 PDPItemAddedModal.propTypes = {
     open: PropTypes.bool,
-    product: PropTypes.object,
+    price: PropTypes.string,
+    productImage: PropTypes.string,
     quantity: PropTypes.number,
+    title: PropTypes.string,
     onDismiss: PropTypes.func
 }
 
-export default PDPItemAddedModal
+const mapStateToProps = createStructuredSelector({
+    productImage: selectors.getFirstProductImage,
+    open: selectors.getItemAddedModalOpen,
+    quantity: selectors.getQuantityAdded,
+    title: selectors.getProductTitle,
+    price: selectors.getProductPrice
+})
+
+const mapDispatchToProps = {
+    onDismiss: stripEvent(actions.closeItemAddedModal)
+}
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(PDPItemAddedModal)

--- a/app/containers/pdp/selectors.js
+++ b/app/containers/pdp/selectors.js
@@ -1,4 +1,5 @@
 import {createSelector} from 'reselect'
+import Immutable from 'immutable'
 import {createGetSelector} from '../../utils/selector-utils'
 import * as globalSelectors from '../../store/selectors'
 import {getSelectorFromState} from '../../utils/router-utils'
@@ -35,3 +36,8 @@ export const getProductTitle = createGetSelector(getSelectedProduct, 'title')
 export const getProductPrice = createGetSelector(getSelectedProduct, 'price')
 export const getProductDescription = createGetSelector(getSelectedProduct, 'description')
 export const getProductCarouselItems = createGetSelector(getSelectedProduct, 'carouselItems')
+export const getFirstProductCarouselItem = createSelector(
+    getProductCarouselItems,
+    (carouselItems) => carouselItems.get(0, Immutable.Map())
+)
+export const getFirstProductImage = createGetSelector(getFirstProductCarouselItem, 'img')

--- a/app/utils/selector-utils.js
+++ b/app/utils/selector-utils.js
@@ -17,3 +17,8 @@ export const createGetSelector = (selector, key) => createSelector(
     selector,
     (obj) => obj.get(key)
 )
+
+export const invertSelector = (selector) => createSelector(
+    selector,
+    (bool) => !bool
+)

--- a/app/utils/selector-utils.js
+++ b/app/utils/selector-utils.js
@@ -8,7 +8,7 @@ export const createImmutableComparingSelector = createSelectorCreator(
 
 export const selectorToJS = (selector) => createImmutableComparingSelector(
     selector,
-    (raw) => raw.toJS()
+    (raw) => { return raw ? raw.toJS() : null }
 )
 
 export const createToJSSelector = (...args) => selectorToJS(createSelector(...args))


### PR DESCRIPTION
Splitting this stage of the refactor into smaller pieces because it's a big one. This PR re-architects the structure of the Header, Footer, Home, and PDP containers so that the Redux store is accessed closer to where the resulting data is used. Footer, Home, and PDP are now functional components with no props, making the top-level code very clean.

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1032
 **Linked PRs**: (links to corresponding PRs, optional)

## Changes
- Connect the Redux store lower down the component tree