### PR TITLE
Upgrade to webpack 2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "svgo": "0.7.1",
     "text-loader": "0.0.1",
     "validator": "6.2.0",
-    "webpack": "2.2",
+    "webpack": "2.2.0",
     "webpack-dev-server": "1.16.2",
     "webpack-hot-middleware": "2.13.0"
   },

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "svgo": "0.7.1",
     "text-loader": "0.0.1",
     "validator": "6.2.0",
-    "webpack": "2.1.0-beta.27",
+    "webpack": "2.2",
     "webpack-dev-server": "1.16.2",
     "webpack-hot-middleware": "2.13.0"
   },

--- a/webpack/dev.js
+++ b/webpack/dev.js
@@ -20,7 +20,7 @@ mainConfig.module.rules = mainConfig.module.rules.concat({
 mainConfig.output.publicPath = `https://${ip.address()}:8443/`
 
 mainConfig.plugins = mainConfig.plugins.concat([
-    new webpack.NoErrorsPlugin()
+    new webpack.NoEmitOnErrorsPlugin()
 ])
 
 workerConfig.plugins = workerConfig.plugins.concat([


### PR DESCRIPTION
Now that the final 2.2 release of webpack has [officially been released](https://medium.com/webpack/webpack-2-2-the-final-release-76c3d43bf144#.5y82q2fwm), this PR upgrades us to it. In future PRs, we will start to take advantage of some new features.

For now, we already benefit from a few improvements, such as the following console output to indicate big chunks when we build our production bundle.:

![image](https://cloud.githubusercontent.com/assets/788827/22116413/44c9e6d8-de25-11e6-8e21-219100550a1e.png)

## Changes
- Upgraded to webpack 2.2
- Replaced the `NoErrorPlugin` with the `NoEmitOnErrorsPlugin`

## How to test-drive this PR
- Run `npm run dev` and preview Merlin's Potions.
  - Verify that the site works as expected.
- Run `npm run prod:build`
  - Verify that the production bundle gets built correctly.
