### PR TITLE
[WEB-1100]:  Fixes Placeholder animation on iOS 10

### DIFF
--- a/app/styles/animations/_background.scss
+++ b/app/styles/animations/_background.scss
@@ -6,10 +6,10 @@
 
 @keyframes background-shimmer {
     0% {
-        transform: translateX(-5000%);
+        transform: translateX(-50000%);
     }
 
     to {
-        transform: translateX(5000%);
+        transform: translateX(50000%);
     }
 }

--- a/app/styles/lib/_background.scss
+++ b/app/styles/lib/_background.scss
@@ -12,8 +12,8 @@
     &::after {
         content: '';
 
-        display: inline-block;
-        width: 10px;
+        display: block;
+        width: 0;
         height: 100%;
 
         background: rgba(0, 0, 0, 0.05);

--- a/app/styles/lib/_background.scss
+++ b/app/styles/lib/_background.scss
@@ -13,7 +13,7 @@
         content: '';
 
         display: block;
-        width: 0;
+        width: 1px;
         height: 100%;
 
         background: rgba(0, 0, 0, 0.05);


### PR DESCRIPTION
Fixes Placeholder animation on iOS 10

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1100

## Changes
- Minimize the size of the box in the pseudo element

## Notes
- There's an Apple known issue where rbga colour is rendered darker on device (due to a rounding error of 0.02 - http://stackoverflow.com/questions/9338827/why-do-browsers-render-rgba-differently-on-osx). This is why the rectangle box is seen on device but not on Chrome desktop.

## How to test-drive this PR
- Can only be seen on device
- Please follow the instruction in this ticket: https://mobify.atlassian.net/browse/WEB-1100
