### PR TITLE
Disable Lighthouse tests for now

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,9 +22,10 @@ test:
         # - npm run smoke-test:
         #    parallel: true
         #    pwd: web
-    post:
-        - cp -R lighthouse/* $CIRCLE_ARTIFACTS:
-            pwd: web
+    # Disabled on January 27, 2017. For some reason, Lighthouse can't connect to Chrome as of Chrome v56.
+    # post:
+    #    - cp -R lighthouse/* $CIRCLE_ARTIFACTS:
+    #        pwd: web
 experimental:
     notify:
         branches:

--- a/circle.yml
+++ b/circle.yml
@@ -15,8 +15,9 @@ test:
             pwd: web
         - npm test -- --runInBand:
             pwd: web
-        - sudo env "PATH=$PATH" npm run test:pwa-ci:
-            pwd: web
+        # Disabled on January 27, 2017. For some reason, Lighthouse can't connect to Chrome as of Chrome v56.
+        # - sudo env "PATH=$PATH" npm run test:pwa-ci:
+        #     pwd: web
         # Enable smoke-test when automated workflow tests have been implemented.
         # - npm run smoke-test:
         #    parallel: true


### PR DESCRIPTION
Lighthouse tests are broken for unknown reasons. A Jira ticket to further investigate that has been created. Half a day of research has not brought any clarity as to why this is happening.

**JIRA**: https://mobify.atlassian.net/browse/WEB-1126

## Changes
- Disabled Lighthouse tests.

## How to test-drive this PR
- Validate CircleCI reports successful test results.