### PR TITLE
Schematize links

### DIFF
--- a/web/app/containers/catalog/products/reducer.js
+++ b/web/app/containers/catalog/products/reducer.js
@@ -1,5 +1,6 @@
 import Immutable from 'immutable'
 import {handleActions} from 'redux-actions'
+import {TextLink} from '../../../utils/parser-utils'
 
 import {isPageType} from '../../../utils/router-utils'
 import {mergePayload} from '../../../utils/reducer-utils'
@@ -14,11 +15,7 @@ export const initialState = Immutable.fromJS({
     [PLACEHOLDER]: {
         title: '',
         price: '',
-        link: {
-            href: '',
-            text: '',
-            title: ''
-        },
+        link: TextLink(),
         image: {
             title: '',
             alt: '',

--- a/web/app/containers/footer/actions.js
+++ b/web/app/containers/footer/actions.js
@@ -4,9 +4,9 @@ import * as utils from '../../utils/utils'
 
 export const receiveData = utils.createAction('Receive footer data')
 
-export const process = ({payload: {$response}}) => receiveData({
+export const process = ({payload: {$, $response}}) => receiveData({
     newsletter: parser.parseNewsLetter($response),
-    navigation: parser.parseNavigation($response)
+    navigation: parser.parseNavigation($, $response)
 })
 
 export const newsletterSignupComplete = utils.createAction('Newsletter signup complete',

--- a/web/app/containers/footer/parsers/parser.js
+++ b/web/app/containers/footer/parsers/parser.js
@@ -7,10 +7,7 @@ export const parseNewsLetter = ($content) => {
     return {action, method}
 }
 
-export const parseNavigation = ($content) => {
+export const parseNavigation = ($, $content) => {
     const $links = $content.find('footer .footer.links li a')
-    return Array.prototype.map.call($links, (link) => {
-        const $link = $(link)
-        return parseTextLink($link)
-    })
+    return [].map.call($links, (link) => parseTextLink($(link)))
 }

--- a/web/app/containers/footer/parsers/parser.js
+++ b/web/app/containers/footer/parsers/parser.js
@@ -7,7 +7,11 @@ export const parseNewsLetter = ($content) => {
     return {action, method}
 }
 
+const FOOTER_LINK_SELECTOR = 'footer .footer.links li a'
+
 export const parseNavigation = ($, $content) => {
-    const $links = $content.find('footer .footer.links li a')
-    return [].map.call($links, (link) => parseTextLink($(link)))
+    return [].map.call(
+        $content.find(FOOTER_LINK_SELECTOR),
+        (link) => parseTextLink($(link))
+    )
 }

--- a/web/app/containers/footer/parsers/parser.js
+++ b/web/app/containers/footer/parsers/parser.js
@@ -1,3 +1,4 @@
+import {parseTextLink} from '../../../utils/parser-utils'
 
 export const parseNewsLetter = ($content) => {
     const $form = $content.find('footer .form.subscribe')
@@ -10,9 +11,6 @@ export const parseNavigation = ($content) => {
     const $links = $content.find('footer .footer.links li a')
     return Array.prototype.map.call($links, (link) => {
         const $link = $(link)
-        return {
-            title: $link.text(),
-            href: $link.attr('href')
-        }
+        return parseTextLink($link)
     })
 }

--- a/web/app/containers/footer/parsers/parser.test.js
+++ b/web/app/containers/footer/parsers/parser.test.js
@@ -42,6 +42,6 @@ describe('the footer parser', () => {
                 title: undefined
             })
         ]
-        expect(parser.parseNavigation($content)).toEqual(expected)
+        expect(parser.parseNavigation($, $content)).toEqual(expected)
     })
 })

--- a/web/app/containers/footer/parsers/parser.test.js
+++ b/web/app/containers/footer/parsers/parser.test.js
@@ -1,5 +1,6 @@
 import {jquerifyHtmlFile} from 'progressive-web-sdk/dist/test-utils'
 import * as parser from './parser'
+import {TextLink} from '../../../utils/parser-utils'
 
 describe('the footer parser', () => {
 
@@ -15,26 +16,31 @@ describe('the footer parser', () => {
 
     test('should extract footer navigation from the rendered HTML', () => {
         const expected = [
-            {
-                title: 'Privacy and Cookie Policy',
-                href: 'http://www.merlinspotions.com/privacy-policy-cookie-restriction-mode/'
-            },
-            {
-                title: 'Search Terms',
-                href: 'http://www.merlinspotions.com/search/term/popular/'
-            },
-            {
-                title: 'Contact Us',
-                href: 'http://www.merlinspotions.com/contact/'
-            },
-            {
-                title: 'Orders and Returns',
-                href: 'http://www.merlinspotions.com/sales/guest/form/'
-            },
-            {
-                title: 'Advanced Search',
-                href: 'http://www.merlinspotions.com/catalogsearch/advanced/'
-            }
+            TextLink({
+                text: 'Privacy and Cookie Policy',
+                href: 'http://www.merlinspotions.com/privacy-policy-cookie-restriction-mode/',
+                title: undefined
+            }),
+            TextLink({
+                text: 'Search Terms',
+                href: 'http://www.merlinspotions.com/search/term/popular/',
+                title: undefined
+            }),
+            TextLink({
+                text: 'Contact Us',
+                href: 'http://www.merlinspotions.com/contact/',
+                title: undefined
+            }),
+            TextLink({
+                text: 'Orders and Returns',
+                href: 'http://www.merlinspotions.com/sales/guest/form/',
+                title: undefined
+            }),
+            TextLink({
+                text: 'Advanced Search',
+                href: 'http://www.merlinspotions.com/catalogsearch/advanced/',
+                title: undefined
+            })
         ]
         expect(parser.parseNavigation($content)).toEqual(expected)
     })

--- a/web/app/containers/footer/partials/footer-navigation.jsx
+++ b/web/app/containers/footer/partials/footer-navigation.jsx
@@ -11,10 +11,10 @@ import SkeletonText from 'progressive-web-sdk/dist/components/skeleton-text'
 const FooterNavigation = ({navigation}) => {
     return (
         <div className="t-footer__navigation u-padding-lg u-text-align-center">
-            {navigation.map(({title, href}, index) => {
+            {navigation.map(({text, href}, index) => {
                 return (
                     <ListTile href={href} key={index}>
-                        {title || <SkeletonText width="135px" style={{lineHeight: '20px'}} />}
+                        {text || <SkeletonText width="135px" style={{lineHeight: '20px'}} />}
                     </ListTile>
                 )
             })}

--- a/web/app/containers/footer/reducer.js
+++ b/web/app/containers/footer/reducer.js
@@ -3,13 +3,11 @@ import {handleActions} from 'redux-actions'
 import * as footerActions from './actions'
 import * as constants from './constants'
 import {mergePayload} from '../../utils/reducer-utils'
+import {TextLink} from '../../utils/parser-utils'
 
 export const initialState = Immutable.fromJS({
     newsletter: null,
-    navigation: new Array(5).fill({
-        title: null,
-        href: null
-    }),
+    navigation: new Array(5).fill(TextLink()),
     signupStatus: constants.SIGNUP_NOT_ATTEMPTED
 })
 

--- a/web/app/utils/parser-utils.js
+++ b/web/app/utils/parser-utils.js
@@ -1,9 +1,17 @@
+import Immutable from 'immutable'
+
+export const TextLink = Immutable.Record({
+    href: '',
+    text: '',
+    title: ''
+})
+
 export const parseTextLink = ($link) => {
-    return {
+    return TextLink({
         href: $link.attr('href'),
         text: $link.text(),
         title: $link.attr('title')
-    }
+    })
 }
 
 export const parseButton = ($button) => {

--- a/web/app/utils/parser-utils.test.js
+++ b/web/app/utils/parser-utils.test.js
@@ -2,11 +2,11 @@ import * as ParserUtils from './parser-utils'
 
 test('parseTextLink returns the correct href, text, and title', () => {
     expect(ParserUtils.parseTextLink($('<a href="/test.html" title="Test">Click Here!</a>')))
-        .toEqual({
+        .toEqual(ParserUtils.TextLink({
             href: '/test.html',
             text: 'Click Here!',
             title: 'Test'
-        })
+        }))
 })
 
 test('parseButton returns the correct values', () => {


### PR DESCRIPTION
This PR introduces an Immutable Record type for a text link, as parsed by the `parseTextLink` function. The Record definition is temporarily placed in parser-utils.js in the absence of a general schema.

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1118

## Changes
- Introduce the Record definition
- Use it where necessary

## How to test-drive this PR
- Run the tests
- See that the footer and PLP continue to work correctly.
