### PR TITLE
Astro: merlins add sign-in and registration

### DIFF
--- a/native/app/app.js
+++ b/native/app/app.js
@@ -4,14 +4,16 @@
 import Application from 'progressive-app-sdk/application'
 import MobifyPreviewPlugin from 'progressive-app-sdk/plugins/mobifyPreviewPlugin'
 import PreviewController from 'progressive-app-sdk/controllers/previewController'
+import Astro from 'progressive-app-sdk/astro-full'
 
 // Local
 import baseConfig from './config/baseConfig'
 import TabBarController from './controllers/tabBarController'
 import {getInitialTabId} from './config/tabBarConfig'
 import OnboardingModalController, {OnboardingModalEvents} from './onboarding/onboardingModalController'
+import {AccountSegEvents} from './controllers/accountSegmentationController'
 import AppEvents from './global/app-events'
-import Astro from 'progressive-app-sdk/astro-full'
+import rpcMethodNames from './global/app-rpc-method-names'
 
 window.run = async function() {
     const runApp = async function() {
@@ -34,14 +36,14 @@ window.run = async function() {
             Application.setStatusBarLightText()
         })
 
-        Astro.registerRpcMethod('registerShow', [], () => {
+        Astro.registerRpcMethod(rpcMethodNames.registerShow, [], () => {
             tabBarController.selectTab('account')
-            AppEvents.trigger('registerShow')
+            AppEvents.trigger(AccountSegEvents.registerSelected)
         })
 
-        Astro.registerRpcMethod('signInShow', [], () => {
+        Astro.registerRpcMethod(rpcMethodNames.signInShow, [], () => {
             tabBarController.selectTab('account')
-            AppEvents.trigger('signInShow')
+            AppEvents.trigger(AccountSegEvents.signInSelected)
         })
 
         Application.dismissLaunchImage()

--- a/native/app/app.js
+++ b/native/app/app.js
@@ -11,6 +11,7 @@ import TabBarController from './controllers/tabBarController'
 import {getInitialTabId} from './config/tabBarConfig'
 import OnboardingModalController, {OnboardingModalEvents} from './onboarding/onboardingModalController'
 import AppEvents from './global/app-events'
+import Astro from 'progressive-app-sdk/astro-full'
 
 window.run = async function() {
     const runApp = async function() {
@@ -31,6 +32,16 @@ window.run = async function() {
 
         AppEvents.on(OnboardingModalEvents.onboardingHidden, () => {
             Application.setStatusBarLightText()
+        })
+
+        Astro.registerRpcMethod('registerShow', [], () => {
+            tabBarController.selectTab('account')
+            AppEvents.trigger('registerShow')
+        })
+
+        Astro.registerRpcMethod('signInShow', [], () => {
+            tabBarController.selectTab('account')
+            AppEvents.trigger('signInShow')
         })
 
         Application.dismissLaunchImage()

--- a/native/app/config/accountConfig.js
+++ b/native/app/config/accountConfig.js
@@ -1,0 +1,13 @@
+const register = {
+    key: 'register',
+    text: 'Register',
+    url: 'https://www.merlinspotions.com/customer/account/create/'
+}
+
+const signIn = {
+    key: 'signIn',
+    text: 'Sign In',
+    url: 'https://www.merlinspotions.com/customer/account/login/'
+}
+
+export default {register, signIn}

--- a/native/app/config/accountConfig.js
+++ b/native/app/config/accountConfig.js
@@ -10,4 +10,6 @@ const signIn = {
     url: 'https://www.merlinspotions.com/customer/account/login/'
 }
 
-export default {register, signIn}
+const color = '#4E439B'
+
+export default {register, signIn, color}

--- a/native/app/config/tabBarConfig.js
+++ b/native/app/config/tabBarConfig.js
@@ -21,7 +21,7 @@ const tabBarConfig = {
             title: 'Account',
             imageUrl: 'file:///user.png',
             selectedImageUrl: 'file:///user.png',
-            rootUrl: 'https://www.merlinspotions.com/customer/account/login/'
+            rootUrl: 'https://www.merlinspotions.com/customer/account/create/'
         },
         {
             id: 'more',

--- a/native/app/config/tabBarConfig.js
+++ b/native/app/config/tabBarConfig.js
@@ -21,7 +21,7 @@ const tabBarConfig = {
             title: 'Account',
             imageUrl: 'file:///user.png',
             selectedImageUrl: 'file:///user.png',
-            rootUrl: 'https://www.merlinspotions.com'
+            rootUrl: 'https://www.merlinspotions.com/customer/account/login/'
         },
         {
             id: 'more',

--- a/native/app/controllers/accountSegmentationController.js
+++ b/native/app/controllers/accountSegmentationController.js
@@ -2,6 +2,8 @@ import WebViewPlugin from 'progressive-app-sdk/plugins/WebViewPlugin'
 import AnchoredLayoutPlugin from 'progressive-app-sdk/plugins/anchoredLayoutPlugin'
 import SegmentedPlugin from 'progressive-app-sdk/plugins/segmentedPlugin'
 
+import accountConfig from '../config/accountConfig'
+
 const AccountSegmentationController = function(layout, webView, segmentedView) {
     this.layout = layout
     this.webView = webView
@@ -13,20 +15,26 @@ AccountSegmentationController.init = async function() {
     const layout = await AnchoredLayoutPlugin.init()
     const segmentedView = await SegmentedPlugin.init()
 
-    segmentedView.setItems([
-        {
-            key: 'registration',
-            text: 'Registration'
-        },
-        {
-            key: 'sign-in',
-            text: 'Sign-in'
-        }
-    ])
-
     await layout.setContentView(webView)
     await layout.addTopView(segmentedView)
-    await webView.navigate('https://google.ca')
+
+    await segmentedView.setItems([
+        accountConfig.signIn,
+        accountConfig.register
+    ])
+
+    segmentedView.on('itemSelect', (params) => {
+        switch (params.key) {
+            case accountConfig.signIn.key:
+                webView.navigate(accountConfig.signIn.url)
+                break
+            case accountConfig.register.key:
+                webView.navigate(accountConfig.register.url)
+                break
+        }
+    })
+
+    await segmentedView.selectItem(accountConfig.signIn.key)
 
     return new AccountSegmentationController(layout, webView, segmentedView)
 }

--- a/native/app/controllers/accountSegmentationController.js
+++ b/native/app/controllers/accountSegmentationController.js
@@ -1,0 +1,34 @@
+import WebViewPlugin from 'progressive-app-sdk/plugins/WebViewPlugin'
+import AnchoredLayoutPlugin from 'progressive-app-sdk/plugins/anchoredLayoutPlugin'
+import SegmentedPlugin from 'progressive-app-sdk/plugins/segmentedPlugin'
+
+const AccountSegmentationController = function(layout, webView, segmentedView) {
+    this.layout = layout
+    this.webView = webView
+    this.segmentedView = segmentedView
+}
+
+AccountSegmentationController.init = async function() {
+    const webView = await WebViewPlugin.init()
+    const layout = await AnchoredLayoutPlugin.init()
+    const segmentedView = await SegmentedPlugin.init()
+
+    segmentedView.setItems([
+        {
+            key: 'registration',
+            text: 'Registration'
+        },
+        {
+            key: 'sign-in',
+            text: 'Sign-in'
+        }
+    ])
+
+    await layout.setContentView(webView)
+    await layout.addTopView(segmentedView)
+    await webView.navigate('https://google.ca')
+
+    return new AccountSegmentationController(layout, webView, segmentedView)
+}
+
+export default AccountSegmentationController

--- a/native/app/controllers/accountSegmentationController.js
+++ b/native/app/controllers/accountSegmentationController.js
@@ -34,9 +34,17 @@ AccountSegmentationController.init = async function() {
         }
     })
 
-    await segmentedView.selectItem(accountConfig.signIn.key)
+    await segmentedView.selectItem(accountConfig.signIn.key)       // by default loadup signIn
 
     return new AccountSegmentationController(layout, webView, segmentedView)
+}
+
+AccountSegmentationController.prototype.showRegistration = async function() {
+    await this.segmentedView.selectItem(accountConfig.register.key)
+}
+
+AccountSegmentationController.prototype.showSignIn = async function() {
+    await this.segmentedView.selectItem(accountConfig.signIn.key)
 }
 
 export default AccountSegmentationController

--- a/native/app/controllers/accountSegmentationController.js
+++ b/native/app/controllers/accountSegmentationController.js
@@ -3,6 +3,7 @@ import AnchoredLayoutPlugin from 'progressive-app-sdk/plugins/anchoredLayoutPlug
 import SegmentedPlugin from 'progressive-app-sdk/plugins/segmentedPlugin'
 
 import accountConfig from '../config/accountConfig'
+import AppEvents from '../global/app-events'
 
 const AccountSegmentationController = function(layout, webView, segmentedView) {
     this.layout = layout
@@ -37,6 +38,14 @@ AccountSegmentationController.init = async function() {
     })
 
     await segmentedView.selectItem(accountConfig.signIn.key)       // by default loadup signIn
+
+    AppEvents.on('registerShow', () => {
+        segmentedView.selectItem(accountConfig.register.key)
+    })
+
+    AppEvents.on('signInShow', () => {
+        segmentedView.selectItem(accountConfig.signIn.key)
+    })
 
     return new AccountSegmentationController(layout, webView, segmentedView)
 }

--- a/native/app/controllers/accountSegmentationController.js
+++ b/native/app/controllers/accountSegmentationController.js
@@ -5,6 +5,13 @@ import SegmentedPlugin from 'progressive-app-sdk/plugins/segmentedPlugin'
 import accountConfig from '../config/accountConfig'
 import AppEvents from '../global/app-events'
 
+const AccountSegEvents = {
+    // raised when onboarding modal is hidden
+    registerSelected: 'account:register',
+    // raised when onboarding modal is displayed
+    signInSelected: 'account:signIn'
+}
+
 const AccountSegmentationController = function(layout, webView, segmentedView) {
     this.layout = layout
     this.webView = webView
@@ -39,11 +46,11 @@ AccountSegmentationController.init = async function() {
 
     await segmentedView.selectItem(accountConfig.signIn.key)       // by default loadup signIn
 
-    AppEvents.on('registerShow', () => {
+    AppEvents.on(AccountSegEvents.registerSelected, () => {
         segmentedView.selectItem(accountConfig.register.key)
     })
 
-    AppEvents.on('signInShow', () => {
+    AppEvents.on(AccountSegEvents.signInSelected, () => {
         segmentedView.selectItem(accountConfig.signIn.key)
     })
 
@@ -57,5 +64,7 @@ AccountSegmentationController.prototype.showRegistration = async function() {
 AccountSegmentationController.prototype.showSignIn = async function() {
     await this.segmentedView.selectItem(accountConfig.signIn.key)
 }
+
+export {AccountSegEvents}
 
 export default AccountSegmentationController

--- a/native/app/controllers/accountSegmentationController.js
+++ b/native/app/controllers/accountSegmentationController.js
@@ -23,6 +23,8 @@ AccountSegmentationController.init = async function() {
         accountConfig.register
     ])
 
+    await segmentedView.setColor(accountConfig.color)
+
     segmentedView.on('itemSelect', (params) => {
         switch (params.key) {
             case accountConfig.signIn.key:

--- a/native/app/controllers/tabController.js
+++ b/native/app/controllers/tabController.js
@@ -6,9 +6,11 @@ import NavigationPlugin from 'progressive-app-sdk/plugins/navigationPlugin'
 import CounterBadgeController from 'progressive-app-sdk/controllers/counterBadgeController'
 
 import CartModalController from './cartModalController'
+import AccountSegmentationController from './accountSegmentationController'
 
 import baseConfig from '../config/baseConfig'
 import cartConfig from '../config/cartConfig'
+// import tabBarConfig from '../config/tabBarConfig'
 
 const TabController = function(tabItem, layout, headerBar, navigationView, counterBadgeController) {
     this.tabItem = tabItem
@@ -20,7 +22,6 @@ const TabController = function(tabItem, layout, headerBar, navigationView, count
 
     this.isActive = false
     this.loaded = false
-    console.log('TabController constructor finished')
 }
 
 TabController.init = async function(tabItem) {
@@ -39,8 +40,13 @@ TabController.init = async function(tabItem) {
     const counterBadgePlugin = await counterBadgeController.generatePlugin()
 
     await layout.addTopView(headerBar)
-    await layout.setContentView(navigationView)
-    await navigationView.setHeaderBar(headerBar)
+    if (tabItem.id === 'account') {
+        const accountController = await AccountSegmentationController.init()
+        await layout.setContentView(accountController.layout)
+    } else {
+        await layout.setContentView(navigationView)
+        await navigationView.setHeaderBar(headerBar)
+    }
 
     await headerBar.setCenterIcon(baseConfig.logoUrl, 'logo')
     await headerBar.setRightPlugin(counterBadgePlugin, cartConfig.cartIcon.id)
@@ -93,6 +99,10 @@ TabController.prototype.reload = async function() {
 }
 
 TabController.prototype.activate = function() {
+    if (this.tabItem.id === 'account') {
+        return
+    }
+
     if (this.isActive) {
         this.navigationView.popToRoot({animated: true})
     } else {

--- a/native/app/controllers/tabController.js
+++ b/native/app/controllers/tabController.js
@@ -40,7 +40,7 @@ TabController.init = async function(tabItem) {
     const counterBadgePlugin = await counterBadgeController.generatePlugin()
 
     await layout.addTopView(headerBar)
-    if (tabItem.id === 'account') {
+    if (tabItem.id === 'account') {                                                 // The account page does not require navigationView, instead using webView
         const accountController = await AccountSegmentationController.init()
         await layout.setContentView(accountController.layout)
     } else {
@@ -99,6 +99,7 @@ TabController.prototype.reload = async function() {
 }
 
 TabController.prototype.activate = function() {
+    // Don't know how to handle this yet so on account, don't do anything for now....
     if (this.tabItem.id === 'account') {
         return
     }

--- a/native/app/controllers/tabController.js
+++ b/native/app/controllers/tabController.js
@@ -10,7 +10,6 @@ import AccountSegmentationController from './accountSegmentationController'
 
 import baseConfig from '../config/baseConfig'
 import cartConfig from '../config/cartConfig'
-// import tabBarConfig from '../config/tabBarConfig'
 
 const TabController = function(tabItem, layout, headerBar, navigationView, counterBadgeController) {
     this.tabItem = tabItem

--- a/native/app/global/app-rpc-method-names.js
+++ b/native/app/global/app-rpc-method-names.js
@@ -1,7 +1,9 @@
 
 const rpcMethodNames = {
     onboardingShow: 'onboardingShow',
-    onboardingHide: 'onboardingHide'
+    onboardingHide: 'onboardingHide',
+    signInShow: 'signInShow',
+    registerShow: 'registerShow'
 }
 
 export default rpcMethodNames

--- a/native/app/global/app-rpc.js
+++ b/native/app/global/app-rpc.js
@@ -8,5 +8,7 @@ AppRpc.names = rpcMethodNames
 AppRpc.onboardingShow = Astro.jsRpcMethod(AppRpc.names.onboardingShow, [])
 AppRpc.onboardingHide = Astro.jsRpcMethod(AppRpc.names.onboardingHide, [])
 AppRpc.onboardingHasHeader = Astro.jsRpcMethod(AppRpc.names.onboardingHasHeader, [])
+AppRpc.registerShow = Astro.jsRpcMethod(AppRpc.names.registerShow, [])
+AppRpc.signInShow = Astro.jsRpcMethod(AppRpc.names.signInShow, [])
 
 export default AppRpc

--- a/native/onboarding/src/components/Onboarding.js
+++ b/native/onboarding/src/components/Onboarding.js
@@ -23,37 +23,45 @@ class Onboarding extends Component {
 
 function OnboardingScreen(props) {
     const data = props.data
-    const item =  
+    const item =
     <CarouselItem caption="Get started" key={props.index} className="carousel-item" allowLooping="false">
         <div className="carousel-item-wrapper u-direction-column">
             <div className="u-flex u-flexbox u-align-center u-justify-center">
                 <div>
                     <img src={data.imageURL} className="carousel-item-image" alt={data.imageAlt}/>
                     {data.title &&
-                        <h2 className="item-title u-color-neutral-60 u-text-font-family u-text-semi-bold">{data.title}</h2>    
+                        <h2 className="item-title u-color-neutral-60 u-text-font-family u-text-semi-bold">{data.title}</h2>
                     }
                     <p className="item-subtitle u-text-font-family">{data.subtitle}</p>
                 </div>
             </div>
             {data.primaryButtonTitle &&
                 <div className="u-flexbox u-flexbox-gutters button-wrapper">
-                    <Button text={data.primaryButtonTitle} className="c--primary u-flex" />
+                    <Button text={data.primaryButtonTitle} className="c--primary u-flex" onClick={onRegisterTapped}/>
                 </div>
             }
-            
+
             <div className="u-flexbox u-flexbox-gutters button-wrapper">
                 {props.isLast &&
                     <Button className="c--tertiary u-flex" text={data.laterButtonTitle} onClick={onLaterTapped} />
                 }
-                <Button className="c--secondary u-flex" text={data.actionButtonTitle} />
+                <Button className="c--secondary u-flex" text={data.actionButtonTitle} onClick={onSignInTapped} />
             </div>
         </div>
     </CarouselItem>
     return item
 }
 
+function onRegisterTapped(event) {
+    Astro.jsRpcMethod(rpcMethodNames.registerShow, [])();
+}
+
 function onLaterTapped(event) {
     Astro.jsRpcMethod(rpcMethodNames.onboardingHide, [])();
+}
+
+function onSignInTapped(event) {
+    Astro.jsRpcMethod(rpcMethodNames.signInShow, [])();
 }
 
 export default Onboarding

--- a/native/onboarding/src/components/Onboarding.js
+++ b/native/onboarding/src/components/Onboarding.js
@@ -54,6 +54,7 @@ function OnboardingScreen(props) {
 
 function onRegisterTapped(event) {
     Astro.jsRpcMethod(rpcMethodNames.registerShow, [])();
+    Astro.jsRpcMethod(rpcMethodNames.onboardingHide, [])();
 }
 
 function onLaterTapped(event) {
@@ -62,6 +63,7 @@ function onLaterTapped(event) {
 
 function onSignInTapped(event) {
     Astro.jsRpcMethod(rpcMethodNames.signInShow, [])();
+    Astro.jsRpcMethod(rpcMethodNames.onboardingHide, [])();
 }
 
 export default Onboarding

--- a/web/app/containers/login/container.js
+++ b/web/app/containers/login/container.js
@@ -16,8 +16,12 @@ import * as actions from './actions'
 class Login extends React.Component {
 
     // a few constants to make refactoring easier in future
-    static get SIGN_IN_SECTION() { return 'signin' }
-    static get REGISTER_SECTION() { return 'register' }
+    static get SIGN_IN_SECTION() {
+        return 'signin'
+    }
+    static get REGISTER_SECTION() {
+        return 'register'
+    }
     static get SECTION_NAMES() {
         return {
             [Login.SIGN_IN_SECTION]: 'Sign In',
@@ -26,11 +30,15 @@ class Login extends React.Component {
     }
 
     indexForSection(sectionName) {
-        return sectionName === Login.REGISTER_SECTION ? 1 : 0
+        return sectionName === Login.REGISTER_SECTION
+            ? 1
+            : 0
     }
 
     sectionForIndex(activeIndex) {
-        return activeIndex === 1 ? Login.REGISTER_SECTION : Login.SIGN_IN_SECTION
+        return activeIndex === 1
+            ? Login.REGISTER_SECTION
+            : Login.SIGN_IN_SECTION
     }
 
     render() {
@@ -43,7 +51,9 @@ class Login extends React.Component {
             openInfoModal,
             closeInfoModal,
             navigateToSection,
-            route: {routeName},
+            route: {
+                routeName
+            },
             router,
             routes
         } = this.props
@@ -54,99 +64,140 @@ class Login extends React.Component {
         const openRegisterModal = () => openInfoModal(Login.REGISTER_SECTION)
         const closeRegisterModal = () => closeInfoModal(Login.REGISTER_SECTION)
 
-        return (
-            <div className="t-login">
-                {!isRunningInAstro &&
-                <div className="u-bg-color-neutral-20 u-padding-md u-padding-top-lg u-padding-bottom-lg u-box-shadow-inset">
-                    {title ?
-                        <h1 className="u-text-uppercase u-text-normal">
-                            {title}
-                        </h1>
-                    :
-                        <div className="u-padding-md">
-                            <SkeletonBlock height="32px" width="50%" />
-                        </div>
-                    }
-                </div>
-                }
-
-                <Tabs activeIndex={this.indexForSection(routeName)} className="t-login__navigation" onChange={(index) => navigateToSection(router, routes, this.sectionForIndex(index))}>
-                    <TabsPanel title={Login.SECTION_NAMES[Login.SIGN_IN_SECTION]}>
-                        <div className="u-padding-start-md u-padding-end-md u-padding-top-lg u-padding-bottom-lg u-box-shadow">
-                            <div className="u-margin-bottom">
-                                {signinSection.heading ?
-                                    <h2 className="u-h3 u-color-brand u-text-font-family u-text-normal">
+        if (isRunningInAstro && this.indexForSection(routeName) === 0) {
+            return (
+                <div className="t-login">
+                    <div className="u-padding-start-md u-padding-end-md u-padding-top-lg u-padding-bottom-lg u-box-shadow">
+                        <div className="u-margin-bottom">
+                            {signinSection.heading
+                                ? <h2 className="u-h3 u-color-brand u-text-font-family u-text-normal">
                                         {signinSection.heading}
                                     </h2>
-                                :
-                                    <SkeletonBlock height="24px" width="50%" className="u-margin-bottom" />
-                                }
-                            </div>
-
-                            {signinSection.description ?
-                                <p>{signinSection.description}</p>
-                            :
-                                <SkeletonText lines={2} size="14px" width="100%" />
+                                : <SkeletonBlock height="24px" width="50%" className="u-margin-bottom"/>
                             }
-
-                            <div className="u-margin-top">
-                                {signinSection.requiredText ?
-                                    signinSection.requiredText
-                                :
-                                    <SkeletonText lines={1} size="14px" width="33%" />
-                                }
-                            </div>
                         </div>
 
-                        <div className="u-bg-color-neutral-20 u-padding-start-md u-padding-end-md u-padding-top-lg u-padding-bottom-lg u-box-shadow-inset">
-                            <SignInForm {...signinSection.form}
-                                disabled={!signinSection.form.href}
-                                submitForm={submitSignInForm}
-                                openModal={openSignInModal}
-                                closeModal={closeSignInModal}
-                                modalOpen={signinSection.infoModalOpen}
-                            />
-                        </div>
-                    </TabsPanel>
+                        {signinSection.description
+                            ? <p>{signinSection.description}</p>
+                            : <SkeletonText lines={2} size="14px" width="100%"/>
+                        }
 
-                    <TabsPanel title={Login.SECTION_NAMES[Login.REGISTER_SECTION]}>
-                        <div className="u-padding-start-md u-padding-end-md u-padding-top-lg u-padding-bottom-lg u-box-shadow">
-                            {registerSection.heading ?
-                                <h3 className="u-margin-bottom u-color-brand u-text-font-family u-text-normal">
+                        <div className="u-margin-top">
+                            {signinSection.requiredText
+                                ? signinSection.requiredText
+                                : <SkeletonText lines={1} size="14px" width="33%"/>
+                            }
+                        </div>
+                    </div>
+
+                    <div className="u-bg-color-neutral-20 u-padding-start-md u-padding-end-md u-padding-top-lg u-padding-bottom-lg u-box-shadow-inset">
+                        <SignInForm {...signinSection.form} disabled={!signinSection.form.href} submitForm={submitSignInForm} openModal={openSignInModal} closeModal={closeSignInModal} modalOpen={signinSection.infoModalOpen}/>
+                    </div>
+                </div>
+            )
+        } else if (isRunningInAstro && this.indexForSection(routeName) === 1) {
+            return (
+                <div className="t-login">
+                    <div className="u-padding-start-md u-padding-end-md u-padding-top-lg u-padding-bottom-lg u-box-shadow">
+                        {registerSection.heading
+                            ? <h3 className="u-margin-bottom u-color-brand u-text-font-family u-text-normal">
                                     {registerSection.heading}
                                 </h3>
-                            :
-                                <SkeletonBlock height="24px" width="50%" className="u-margin-bottom" />
-                            }
+                            : <SkeletonBlock height="24px" width="50%" className="u-margin-bottom"/>
+                        }
 
-                            {registerSection.description ?
-                                <p>{registerSection.description}</p>
-                            :
-                                <SkeletonText lines={3} size="14px" width="100%" />
-                            }
+                        {registerSection.description
+                            ? <p>{registerSection.description}</p>
+                            : <SkeletonText lines={3} size="14px" width="100%"/>
+                        }
 
-                            <div className="u-margin-top">
-                                {registerSection.requiredText ?
-                                    registerSection.requiredText
-                                :
-                                    <SkeletonText lines={1} size="14px" width="33%" />
-                                }
+                        <div className="u-margin-top">
+                            {registerSection.requiredText
+                                ? registerSection.requiredText
+                                : <SkeletonText lines={1} size="14px" width="33%"/>
+                            }
+                        </div>
+                    </div>
+
+                    <div className="u-bg-color-neutral-20 u-padding-start-md u-padding-end-md u-padding-top-lg u-padding-bottom-lg u-box-shadow-inset">
+                        <RegisterForm {...registerSection.form} disabled={!registerSection.form.href} submitForm={submitRegisterForm} openModal={openRegisterModal} closeModal={closeRegisterModal} modalOpen={registerSection.infoModalOpen}/>
+                    </div>
+                </div>
+            )
+        } else {
+            return (
+                <div className="t-login">
+                    <div className="u-bg-color-neutral-20 u-padding-md u-padding-top-lg u-padding-bottom-lg u-box-shadow-inset">
+                        {title
+                            ? <h1 className="u-text-uppercase u-text-normal">
+                                    {title}
+                                </h1>
+                            : <div className="u-padding-md">
+                                <SkeletonBlock height="32px" width="50%"/>
                             </div>
-                        </div>
+                        }
+                    </div>
 
-                        <div className="u-bg-color-neutral-20 u-padding-start-md u-padding-end-md u-padding-top-lg u-padding-bottom-lg u-box-shadow-inset">
-                            <RegisterForm {...registerSection.form}
-                                disabled={!registerSection.form.href}
-                                submitForm={submitRegisterForm}
-                                openModal={openRegisterModal}
-                                closeModal={closeRegisterModal}
-                                modalOpen={registerSection.infoModalOpen}
-                            />
-                        </div>
-                    </TabsPanel>
-                </Tabs>
-            </div>
-        )
+                    <Tabs activeIndex={this.indexForSection(routeName)} className="t-login__navigation" onChange={(index) => navigateToSection(router, routes, this.sectionForIndex(index))}>
+                        <TabsPanel title={Login.SECTION_NAMES[Login.SIGN_IN_SECTION]}>
+                            <div className="u-padding-start-md u-padding-end-md u-padding-top-lg u-padding-bottom-lg u-box-shadow">
+                                <div className="u-margin-bottom">
+                                    {signinSection.heading
+                                        ? <h2 className="u-h3 u-color-brand u-text-font-family u-text-normal">
+                                                {signinSection.heading}
+                                            </h2>
+                                        : <SkeletonBlock height="24px" width="50%" className="u-margin-bottom"/>
+                                    }
+                                </div>
+
+                                {signinSection.description
+                                    ? <p>{signinSection.description}</p>
+                                    : <SkeletonText lines={2} size="14px" width="100%"/>
+                                }
+
+                                <div className="u-margin-top">
+                                    {signinSection.requiredText
+                                        ? signinSection.requiredText
+                                        : <SkeletonText lines={1} size="14px" width="33%"/>
+                                    }
+                                </div>
+                            </div>
+
+                            <div className="u-bg-color-neutral-20 u-padding-start-md u-padding-end-md u-padding-top-lg u-padding-bottom-lg u-box-shadow-inset">
+                                <SignInForm {...signinSection.form} disabled={!signinSection.form.href} submitForm={submitSignInForm} openModal={openSignInModal} closeModal={closeSignInModal} modalOpen={signinSection.infoModalOpen}/>
+                            </div>
+                        </TabsPanel>
+
+                        <TabsPanel title={Login.SECTION_NAMES[Login.REGISTER_SECTION]}>
+                            <div className="u-padding-start-md u-padding-end-md u-padding-top-lg u-padding-bottom-lg u-box-shadow">
+                                {registerSection.heading
+                                    ? <h3 className="u-margin-bottom u-color-brand u-text-font-family u-text-normal">
+                                            {registerSection.heading}
+                                        </h3>
+                                    : <SkeletonBlock height="24px" width="50%" className="u-margin-bottom"/>
+}
+
+                                {registerSection.description
+                                    ? <p>{registerSection.description}</p>
+                                    : <SkeletonText lines={3} size="14px" width="100%"/>
+}
+
+                                <div className="u-margin-top">
+                                    {registerSection.requiredText
+                                        ? registerSection.requiredText
+                                        : <SkeletonText lines={1} size="14px" width="33%"/>
+}
+                                </div>
+                            </div>
+
+                            <div className="u-bg-color-neutral-20 u-padding-start-md u-padding-end-md u-padding-top-lg u-padding-bottom-lg u-box-shadow-inset">
+                                <RegisterForm {...registerSection.form} disabled={!registerSection.form.href} submitForm={submitRegisterForm} openModal={openRegisterModal} closeModal={closeRegisterModal} modalOpen={registerSection.infoModalOpen}/>
+                            </div>
+                        </TabsPanel>
+                    </Tabs>
+                </div>
+            )
+        }
     }
 }
 
@@ -178,7 +229,4 @@ Login.propTypes = {
     title: PropTypes.string
 }
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps
-)(withRouter(Login))
+export default connect(mapStateToProps, mapDispatchToProps)(withRouter(Login))

--- a/web/app/containers/login/container.js
+++ b/web/app/containers/login/container.js
@@ -9,6 +9,8 @@ import SkeletonBlock from 'progressive-web-sdk/dist/components/skeleton-block'
 import SkeletonText from 'progressive-web-sdk/dist/components/skeleton-text'
 import {Tabs, TabsPanel} from 'progressive-web-sdk/dist/components/tabs'
 
+import {isRunningInAstro} from '../../utils/astro-integration'
+
 import * as actions from './actions'
 
 class Login extends React.Component {
@@ -54,6 +56,7 @@ class Login extends React.Component {
 
         return (
             <div className="t-login">
+                {!isRunningInAstro &&
                 <div className="u-bg-color-neutral-20 u-padding-md u-padding-top-lg u-padding-bottom-lg u-box-shadow-inset">
                     {title ?
                         <h1 className="u-text-uppercase u-text-normal">
@@ -65,6 +68,7 @@ class Login extends React.Component {
                         </div>
                     }
                 </div>
+                }
 
                 <Tabs activeIndex={this.indexForSection(routeName)} className="t-login__navigation" onChange={(index) => navigateToSection(router, routes, this.sectionForIndex(index))}>
                     <TabsPanel title={Login.SECTION_NAMES[Login.SIGN_IN_SECTION]}>


### PR DESCRIPTION
Adds sign-in and registration component to merlins potions demo app. This branch is a combination of 3 different PRs: #274, #275 and #279.

 **JIRA**: https://mobify.atlassian.net/browse/HYB-982
 **Linked PRs**: #274, #275, #279

 Once all 3 PRs are approved, this is the branch that should be merged into the base

## Changes
- removes web title and web tabs in the account #274 
- adds native tabs for registration and sign-in #275 
- from onboarding clicking registration or sign-in leads the user to the account tab with the correct section #279

## How to test-drive this PR
- navigate to `native/onboarding` and run `npm run build` to load the new onboarding page
- launch the app with onboarding on
- a. click register : leads the user to the account tab with registration page loaded
- b. click sign in : leads the user to the account tab with sign in page loaded
- switch between the register and sign in tab, the app should load the correct page
