### PR TITLE
Replace @extend with @include

### DIFF
--- a/web/app/styles/_lib.scss
+++ b/web/app/styles/_lib.scss
@@ -3,3 +3,4 @@
 
 @import 'lib/color';
 @import 'lib/background';
+@import 'lib/heading-level';

--- a/web/app/styles/base/_typography.scss
+++ b/web/app/styles/base/_typography.scss
@@ -26,40 +26,28 @@ h6 {
     line-height: 1.25;
 }
 
-h1,
-%h1 {
-    font-size: 28px;
-    line-height: 32px;
+h1 {
+    @include heading-level-1;
 }
 
-h2,
-%h2 {
-    font-size: 20px;
-    line-height: 24px;
+h2 {
+    @include heading-level-2;
 }
 
-h3,
-%h3 {
-    font-size: 18px;
-    line-height: 24px;
+h3 {
+    @include heading-level-3;
 }
 
-h4,
-%h4 {
-    font-size: 18px;
-    line-height: 24px;
+h4 {
+    @include heading-level-4;
 }
 
-h5,
-%h5 {
-    font-size: 16px;
-    line-height: 20px;
+h5 {
+    @include heading-level-5;
 }
 
-h6,
-%h6 {
-    font-size: $font-size;
-    line-height: $line-height;
+h6 {
+    @include heading-level-6;
 }
 
 

--- a/web/app/styles/lib/_heading-level.scss
+++ b/web/app/styles/lib/_heading-level.scss
@@ -1,0 +1,76 @@
+// Heading Level
+// ===
+
+@mixin heading-level-1(// @TODO: Add to spline
+    $important: false
+) {
+    @if($important) {
+        font-size: 28px !important;
+        line-height: 32px !important;
+    } @else {
+        font-size: 28px;
+        line-height: 32px;
+    }
+}
+
+@mixin heading-level-2(// @TODO: Add to spline
+    $important: false
+) {
+    @if($important) {
+        font-size: 20px !important;
+        line-height: 24px !important;
+    } @else {
+        font-size: 20px;
+        line-height: 24px;
+    }
+}
+
+@mixin heading-level-3(// @TODO: Add to spline
+    $important: false
+) {
+    @if($important) {
+        font-size: 18px !important;
+        line-height: 24px !important;
+    } @else {
+        font-size: 18px;
+        line-height: 24px;
+    }
+}
+
+@mixin heading-level-4(// @TODO: Add to spline
+    $important: false
+) {
+    @if($important) {
+        font-size: 18px !important;
+        line-height: 24px !important;
+    } @else {
+        font-size: 18px;
+        line-height: 24px;
+    }
+}
+
+@mixin heading-level-5(// @TODO: Add to spline
+    $important: false
+) {
+    @if($important) {
+        font-size: 16px !important;
+        line-height: 20px !important;
+    } @else {
+        font-size: 16px;
+        line-height: 20px;
+    }
+}
+
+@mixin heading-level-6(// @TODO: Add to spline
+    $important: false,
+    $h6-font-size: if(variable-exists(font-size), $font-size, null),
+    $h6-line-height: if(variable-exists(line-height), $line-height, null)
+) {
+    @if($important) {
+        font-size: $h6-font-size !important;
+        line-height: $h6-line-height !important;
+    } @else {
+        font-size: $h6-font-size;
+        line-height: $h6-line-height;
+    }
+}

--- a/web/app/styles/utilities/_heading.scss
+++ b/web/app/styles/utilities/_heading.scss
@@ -6,25 +6,25 @@
 }
 
 .u-h1 {
-    @extend %h1; // 28px/32px
+    @include heading-level-1(true); // 28px/32px
 }
 
 .u-h2 {
-    @extend %h2; // 20px/24px
+    @include heading-level-2(true); // 20px/24px
 }
 
 .u-h3 {
-    @extend %h3; // 18px/24px
+    @include heading-level-3(true); // 18px/24px
 }
 
 .u-h4 {
-    @extend %h4; // 18px/24px
+    @include heading-level-4(true); // 18px/24px
 }
 
 .u-h5 {
-    @extend %h5; // 16px/20px
+    @include heading-level-5(true); // 16px/20px
 }
 
 .u-h6 {
-    @extend %h6; // 14px/20px
+    @include heading-level-6(true); // 14px/20px
 }

--- a/web/app/styles/utilities/_heading.scss
+++ b/web/app/styles/utilities/_heading.scss
@@ -2,7 +2,7 @@
 // ===
 
 .u-heading-family {
-    font-family: $header-font-family;
+    font-family: $header-font-family !important;
 }
 
 .u-h1 {


### PR DESCRIPTION
This is so we can add !important to the heading utility classes, which
wasn’t possible with extend.

## Changes
- Replace the heading utilities' `@extend` declarations with mixin `@include`s instead.
- Heading utilities now have `!important`, as all utilities are intended to have.

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Visit any page with an html heading and confirm it's base styles have NO `!important`
- Find a head utility class and confirm it has `!important`
- Confirm that all heading levels (1-6) work as intended.
