### PR TITLE
Add common necessary steps to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,5 +8,6 @@
 
 ## How to test-drive this PR
 - (necessary config changes)
-- (necessary corresponding PRs)
+- Run `npm run dev`
+- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
 - (how to access the new / changed functionality -- fixtures, URLs)


### PR DESCRIPTION
Minor improvement to PR template

## Changes
- Remove `(necessary corresponding PRs)` mostly because I haven't noticed it being useful... open to bringing it back
- Add basic runtime steps to get a PR up and running.

## How to test-drive this PR
- Not sure this is testable
- Confirm if you like the template?
