### PR TITLE
Astro: Point app to special *Astro* target bundle

### DIFF
--- a/native/app/config/baseConfig.js
+++ b/native/app/config/baseConfig.js
@@ -17,7 +17,7 @@ const baseConfig = {
     baseURL: 'https://www.merlinspotions.com',
     previewBundle: AstroNative.Configuration.DEBUG
         ? localPreviewUrl
-        : '//cdn.mobify.com/sites/progressive-web-scaffold/production/loader.js',
+        : '//cdn.mobify.com/sites/progressive-web-scaffold/astro/loader.js',
     colors,
     logoUrl: 'file:///logo.png',
 }


### PR DESCRIPTION
Points the app to the `astro` target on Cloud to allow people to test the BuddyBuild builds.

 **JIRA**: (link to JIRA ticket)
 **Linked PRs**: (links to corresponding PRs, optional)

## Changes
- (change1)

## How to test-drive this PR
- (necessary config changes)
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- (how to access the new / changed functionality -- fixtures, URLs)
