### PR TITLE
WEB-1146: Fixes Stepper on PDP on iOS 9.3

### DIFF
--- a/web/app/containers/pdp/_pdp.scss
+++ b/web/app/containers/pdp/_pdp.scss
@@ -16,6 +16,14 @@
 }
 
 
+// In Stock Indicator
+// ---
+
+.t-pdp__indicator {
+    flex: 1 1 auto;
+}
+
+
 // Add to Cart Button
 // ---
 

--- a/web/app/containers/pdp/_pdp.scss
+++ b/web/app/containers/pdp/_pdp.scss
@@ -16,14 +16,6 @@
 }
 
 
-// In Stock Indicator
-// ---
-
-.t-pdp__indicator {
-    flex: 1 1 auto;
-}
-
-
 // Add to Cart Button
 // ---
 

--- a/web/app/containers/pdp/partials/pdp-add-to-cart.jsx
+++ b/web/app/containers/pdp/partials/pdp-add-to-cart.jsx
@@ -16,6 +16,7 @@ const PDPAddToCart = ({quantity, setQuantity, onSubmit, disabled}) => {
         initialValue: quantity,
         minimumValue: 1,
         onChange: setQuantity,
+        className: 'u-flex-none'
     }
 
     if (disabled) {
@@ -32,7 +33,7 @@ const PDPAddToCart = ({quantity, setQuantity, onSubmit, disabled}) => {
                 <div className="u-flexbox u-margin-bottom-lg u-margin-top">
                     <Stepper {...stepperProps} />
 
-                    <div className="t-pdp__indicator u-border u-margin-start u-padding-md u-flexbox u-justify-center">
+                    <div className="t-pdp__indicator u-border u-margin-start u-padding-md  u-flex u-flexbox u-justify-center">
                         <Icon name="check" className="u-margin-end-sm" /> In stock
                     </div>
                 </div>

--- a/web/app/containers/pdp/partials/pdp-add-to-cart.jsx
+++ b/web/app/containers/pdp/partials/pdp-add-to-cart.jsx
@@ -32,7 +32,7 @@ const PDPAddToCart = ({quantity, setQuantity, onSubmit, disabled}) => {
                 <div className="u-flexbox u-margin-bottom-lg u-margin-top">
                     <Stepper {...stepperProps} />
 
-                    <div className="t-pdp__indicator u-border u-margin-start u-padding-md u-flexbox u-justify-center u-width-full">
+                    <div className="t-pdp__indicator u-border u-margin-start u-padding-md u-flexbox u-justify-center">
                         <Icon name="check" className="u-margin-end-sm" /> In stock
                     </div>
                 </div>


### PR DESCRIPTION
Fixes Stepper on PDP on iOS 9.3

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1146

## Changes
- Fixes the issue where the stepper component is squished on iOS 9.3

## How to test-drive this PR
- use iOS 9.3
- Run `npm run dev`
- Preview to: https://www.merlinspotions.com/
- Navigate to a PDP
- Look at the Quantity stepper
- The minus and plus icons should not be squished

