### PR TITLE
Refactor checkout shipping partials

### DIFF
--- a/web/app/app-provider.jsx
+++ b/web/app/app-provider.jsx
@@ -23,7 +23,7 @@ const AppProvider = ({store}) => (
                 <Route component={PLP} path="new-arrivals.html" routeName="productListPage" />
                 <Route component={PLP} path="charms.html" routeName="productListPage" />
                 <Route component={PDP} path="*.html" routeName="productDetailsPage" />
-                <Route component={CheckoutShipping} path="checkout/shipping/" routeName="checkingShipping" suppressFetch Header={CheckoutHeader} Footer={CheckoutFooter} />
+                <Route component={CheckoutShipping} path="checkout/" routeName="checkingShipping" Header={CheckoutHeader} Footer={CheckoutFooter} />
                 <Route component={CheckoutPayment} path="checkout/payment/" routeName="checkingPayment" suppressFetch Header={CheckoutHeader} Footer={CheckoutFooter} />
                 <Route component={CheckoutConfirmation} path="checkout/confirmation/" routeName="checkingConfirmation" suppressFetch Header={CheckoutHeader} Footer={CheckoutFooter} />
             </Route>

--- a/web/app/containers/app/actions.js
+++ b/web/app/containers/app/actions.js
@@ -2,10 +2,12 @@ import {jqueryResponse} from 'progressive-web-sdk/dist/jquery-response'
 import * as utils from '../../utils/utils'
 import * as selectors from './selectors'
 
+import CheckoutShipping from '../checkout-shipping/container'
 import Home from '../home/container'
 import Login from '../login/container'
 import PDP from '../pdp/container'
 import PLP from '../plp/container'
+import * as checkoutShippingActions from '../checkout-shipping/actions'
 import * as homeActions from '../home/actions'
 import * as loginActions from '../login/actions'
 import * as pdpActions from '../pdp/actions'
@@ -64,6 +66,8 @@ export const fetchPage = (url, pageComponent, routeName) => {
                 } else if (pageComponent === PLP) {
                     dispatch(categoriesActions.process(receivedAction))
                     dispatch(productsActions.processPlp(receivedAction))
+                } else if (pageComponent === CheckoutShipping) {
+                    dispatch(checkoutShippingActions.process(receivedAction))
                 }
                 dispatch(footerActions.process(receivedAction))
                 dispatch(navigationActions.process(receivedAction))

--- a/web/app/containers/cart/partials/cart-summary.jsx
+++ b/web/app/containers/cart/partials/cart-summary.jsx
@@ -65,7 +65,7 @@ const CartSummary = ({summaryCount, subtotalExclTax, subtotalInclTax, onCalculat
                 <div className="u-padding-end-md u-padding-bottom-lg u-padding-start-md">
                     <Button
                         className="c--primary u-flex-none u-width-full u-text-uppercase"
-                        href="/checkout/shipping/">
+                        href="/checkout/">
                         <Icon name="lock" />
                         Proceed To Checkout
                     </Button>

--- a/web/app/containers/checkout-shipping/actions.js
+++ b/web/app/containers/checkout-shipping/actions.js
@@ -6,7 +6,7 @@ export const showCompanyAndApt = createAction('Showing the "Company" and "Apt #"
 
 export const receiveData = createAction('Receive Checkout Shipping Data')
 export const process = ({payload: {$, $response}}) => {
-    return receiveData(checkoutShippingParser($, $response))
+    return receiveData({...checkoutShippingParser($, $response), contentsLoaded: true})
 }
 
 export const onShippingEmailRecognized = () => {

--- a/web/app/containers/checkout-shipping/actions.js
+++ b/web/app/containers/checkout-shipping/actions.js
@@ -1,25 +1,12 @@
-import {createAction, makeRequest} from '../../utils/utils'
-import {jqueryResponse} from 'progressive-web-sdk/dist/jquery-response'
+import {createAction} from '../../utils/utils'
 import checkoutShippingParser from './checkout-shipping-parser'
 import {addNotification} from '../app/actions'
 
-export const receiveContents = createAction('Received CheckoutShipping Contents')
 export const showCompanyAndApt = createAction('Showing the "Company" and "Apt #" fields')
 
-export const receiveResponse = (response) => {
-    return (dispatch) => {
-        return jqueryResponse(response)
-            .then(([$, $responseText]) => {
-                dispatch(receiveContents(checkoutShippingParser($, $responseText)))
-            })
-    }
-}
-
-export const fetchContents = () => {
-    return (dispatch) => {
-        return makeRequest(window.location.href)
-            .then((response) => dispatch(receiveResponse(response)))
-    }
+export const receiveData = createAction('Receive Checkout Shipping Data')
+export const process = ({payload: {$, $response}}) => {
+    return receiveData(checkoutShippingParser($, $response))
 }
 
 export const onShippingEmailRecognized = () => {

--- a/web/app/containers/checkout-shipping/actions.js
+++ b/web/app/containers/checkout-shipping/actions.js
@@ -6,7 +6,7 @@ export const showCompanyAndApt = createAction('Showing the "Company" and "Apt #"
 
 export const receiveData = createAction('Receive Checkout Shipping Data')
 export const process = ({payload: {$, $response}}) => {
-    return receiveData({...checkoutShippingParser($, $response), contentsLoaded: true})
+    return receiveData(checkoutShippingParser($, $response))
 }
 
 export const onShippingEmailRecognized = () => {

--- a/web/app/containers/checkout-shipping/actions.test.js
+++ b/web/app/containers/checkout-shipping/actions.test.js
@@ -1,4 +1,4 @@
-import {fetchContents, receiveResponse} from './actions'
+import {process} from './actions'
 
 let realFetch
 beforeAll(() => {
@@ -16,42 +16,12 @@ import {jqueryResponse} from 'progressive-web-sdk/dist/jquery-response'
 jest.mock('./checkout-shipping-parser')
 import checkoutShippingParser from './checkout-shipping-parser'
 
-test('fetchContents dispatches receiveResponse, which dispatches receiveContents', () => {
-    global.fetch.mockClear()
-    global.fetch.mockReturnValueOnce(Promise.resolve('page contents!'))
 
-    const url = 'http://test.mobify.com/'
-
-    /**
-     * We don't have the ability to change window.location.href, so we mock it
-     * as a workaround
-     * @url - https://github.com/tmpvar/jsdom#changing-the-url-of-an-existing-jsdom-window-instance
-     * @url - https://github.com/facebook/jest/issues/890#issuecomment-209698782
-     */
-    Object.defineProperty(window.location, 'href', {
-        writable: true,
-        value: url
-    })
-
-    const thunk = fetchContents()
-    expect(typeof thunk).toBe('function')
-
-    const mockDispatch = jest.fn()
-
-    return thunk(mockDispatch)
-        .then(() => {
-            expect(global.fetch).toBeCalled()
-            expect(global.fetch.mock.calls[0][0]).toBe(url)
-
-            expect(mockDispatch).toBeCalled()
-        })
-})
-
-test('receiveResponse parses the response and dispatches receiveContents', () => {
+test('process parses the response and dispatches receiveData', () => {
     jqueryResponse.mockClear()
     jqueryResponse.mockReturnValue(Promise.resolve(['$', '$response']))
 
-    const thunk = receiveResponse('page contents!')
+    const thunk = process('page contents!')
     expect(typeof thunk).toBe('function')
 
     const mockDispatch = jest.fn()

--- a/web/app/containers/checkout-shipping/checkout-shipping-parser.js
+++ b/web/app/containers/checkout-shipping/checkout-shipping-parser.js
@@ -1,9 +1,13 @@
+import {extractMagentoJson} from '../../utils/magento-utils'
+
+
+const SHIPPING_STEP_PATH = ['#checkout', 'Magento_Ui/js/core/app', 'components', 'checkout', 'children', 'steps', 'children', 'shipping-step', 'children', 'shippingAddress']
+
 const checkoutShippingParser = ($, $html) => {
-    const body = $html.find('body').html()
+    const shippingStepData = extractMagentoJson($html).getIn(SHIPPING_STEP_PATH)
 
     return {
-        testText: 'checkoutShipping Page',
-        body
+        formTitle: shippingStepData.getIn(['config', 'popUpForm', 'options', 'title']),
     }
 }
 

--- a/web/app/containers/checkout-shipping/container.jsx
+++ b/web/app/containers/checkout-shipping/container.jsx
@@ -25,15 +25,12 @@ class CheckoutShipping extends React.Component {
 
     render() {
         const {
-            contentsLoaded,
             isCompanyOrAptShown,
             formTitle
         } = this.props.checkoutShipping.toJS()
         const {onShippingEmailRecognized} = this.props
 
-        const templateClassnames = classNames('t-checkout-shipping u-bg-color-neutral-20', {
-            't--loaded': contentsLoaded
-        })
+        const templateClassnames = classNames('t-checkout-shipping u-bg-color-neutral-20 t--loaded')
 
         return (
             <div className={templateClassnames}>

--- a/web/app/containers/checkout-shipping/container.jsx
+++ b/web/app/containers/checkout-shipping/container.jsx
@@ -30,7 +30,8 @@ class CheckoutShipping extends React.Component {
     render() {
         const {
             contentsLoaded,
-            isCompanyOrAptShown
+            isCompanyOrAptShown,
+            formTitle
         } = this.props.checkoutShipping.toJS()
         const {onShippingEmailRecognized} = this.props
 
@@ -51,13 +52,12 @@ class CheckoutShipping extends React.Component {
                     </div>
                 </div>
 
-                {contentsLoaded &&
-                    <CheckoutShippingReduxForm
-                        isCompanyOrAptShown={isCompanyOrAptShown}
-                        handleShowCompanyAndApt={this.handleShowCompanyAndApt}
-                        onShippingEmailRecognized={onShippingEmailRecognized}
-                    />
-                }
+                <CheckoutShippingReduxForm
+                    formTitle={formTitle}
+                    isCompanyOrAptShown={isCompanyOrAptShown}
+                    handleShowCompanyAndApt={this.handleShowCompanyAndApt}
+                    onShippingEmailRecognized={onShippingEmailRecognized}
+                />
             </div>
         )
     }

--- a/web/app/containers/checkout-shipping/container.jsx
+++ b/web/app/containers/checkout-shipping/container.jsx
@@ -15,10 +15,6 @@ class CheckoutShipping extends React.Component {
         this.handleShowCompanyAndApt = this.handleShowCompanyAndApt.bind(this)
     }
 
-    componentDidMount() {
-        // this.props.fetchContents()
-    }
-
     shouldComponentUpdate(newProps) {
         return !Immutable.is(this.props.checkoutShipping, newProps.checkoutShipping)
     }
@@ -65,7 +61,6 @@ class CheckoutShipping extends React.Component {
 
 CheckoutShipping.propTypes = {
     checkoutShipping: PropTypes.instanceOf(Immutable.Map),
-    fetchContents: PropTypes.func,
     showCompanyAndApt: PropTypes.func,
 
     onShippingEmailRecognized: PropTypes.func,
@@ -78,7 +73,6 @@ const mapStateToProps = (state) => {
 }
 
 const mapDispatchToProps = {
-    fetchContents: checkoutShippingActions.fetchContents,
     showCompanyAndApt: checkoutShippingActions.showCompanyAndApt,
     onShippingEmailRecognized: checkoutShippingActions.onShippingEmailRecognized,
 }

--- a/web/app/containers/checkout-shipping/container.jsx
+++ b/web/app/containers/checkout-shipping/container.jsx
@@ -73,7 +73,7 @@ CheckoutShipping.propTypes = {
 
 const mapStateToProps = (state) => {
     return {
-        checkoutShipping: state.checkoutShipping
+        checkoutShipping: state.ui.checkoutShipping
     }
 }
 

--- a/web/app/containers/checkout-shipping/partials/checkout-shipping-form.jsx
+++ b/web/app/containers/checkout-shipping/partials/checkout-shipping-form.jsx
@@ -6,16 +6,15 @@ import ShippingAddressForm from './shipping-address'
 import ShippingEmail from './shipping-email'
 import ShippingMethod from './shipping-method'
 
-const CheckoutShippingForm = (props) => {
-    const {
-        formTitle,
-        handleShowCompanyAndApt,
-        handleSubmit,
-        isCompanyOrAptShown,
-        onShippingEmailRecognized,
-        // disabled,
-        // submitting
-    } = props
+const CheckoutShippingForm = ({
+    formTitle,
+    handleShowCompanyAndApt,
+    handleSubmit,
+    isCompanyOrAptShown,
+    onShippingEmailRecognized,
+    // disabled,
+    // submitting
+}) => {
 
     return (
         <form className="t-checkout-shipping__form" onSubmit={handleSubmit} noValidate>

--- a/web/app/containers/checkout-shipping/partials/checkout-shipping-form.jsx
+++ b/web/app/containers/checkout-shipping/partials/checkout-shipping-form.jsx
@@ -1,216 +1,14 @@
 import React from 'react'
 import * as ReduxForm from 'redux-form'
 
-import Button from 'progressive-web-sdk/dist/components/button'
-import Field from 'progressive-web-sdk/dist/components/field'
-import FieldRow from 'progressive-web-sdk/dist/components/field-row'
 import {Grid, GridSpan} from '../../../components/grid'
-import {Icon} from 'progressive-web-sdk/dist/components/icon'
-import Link from 'progressive-web-sdk/dist/components/link'
-
-const renderEmailAddress = (onShippingEmailRecognized) => {
-    const passwordHint = (
-        <Link className="u-color-brand" href="/customer/account/forgotpassword/">
-            Forgot password
-        </Link>
-    )
-    const isSigningIn = true
-
-    return (
-        <div>
-            <div className="t-checkout-shipping__email-title" />
-
-            <div className="u-padding-md u-border-light-top u-border-light-bottom u-bg-color-neutral-10">
-                <FieldRow>
-                    <ReduxForm.Field component={Field} className="pw--overlayed-hint" name="email" label="Email my receipt to">
-                        <input type="email" noValidate />
-                    </ReduxForm.Field>
-                </FieldRow>
-
-                {isSigningIn &&
-                    <FieldRow>
-                        <ReduxForm.Field component={Field} name="password" label="Password" hint={passwordHint}>
-                            <input type="password" noValidate />
-                        </ReduxForm.Field>
-                    </FieldRow>
-                }
-
-                {isSigningIn &&
-                    <FieldRow>
-                        <Button
-                            className="c--secondary u-width-full u-text-uppercase"
-                            onClick={onShippingEmailRecognized}>
-                            <Icon name="user" className="u-margin-end" />
-                            Sign In
-                        </Button>
-                    </FieldRow>
-                }
-            </div>
-        </div>
-    )
-}
-
-const renderShippingAddress = (isCompanyOrAptShown, handleShowCompanyAndApt) => {
-    const addCompanyButton = (
-        <Button
-            className="c--is-anchor"
-            innerClassName="c--no-min-height u-padding-0"
-            onClick={handleShowCompanyAndApt}
-            >
-            <span className="u-color-brand u-text-letter-spacing-normal u-text-small">
-                Add company or apt #
-            </span>
-            <Icon name="chevron-down" className="u-margin-start-sm u-color-brand" />
-        </Button>
-    )
-    const shippingAddress = (
-        <div>
-            <p>Vancouver, BC, Canada, V4R5TS</p>
-            <p>Name: John Appleseet</p>
-        </div>
-    )
-
-    return (
-        <div>
-            <div className="t-checkout-shipping__title u-padding-top-lg u-padding-bottom-lg">
-                <h2 className="u-h4">Shipping Address</h2>
-            </div>
-
-            <div className="u-padding-md u-border-light-top u-border-light-bottom u-bg-color-neutral-10">
-                <FieldRow>
-                    <ReduxForm.Field
-                        component={Field}
-                        name="shipping-address"
-                        label={<strong className="u-text-semi-bold">725 West Georgia</strong>}
-                        caption={shippingAddress}
-                    >
-                        <input type="radio" noValidate />
-                    </ReduxForm.Field>
-                </FieldRow>
-
-                <div className="u-padding-md u-margin-top-md u-border-light">
-                    <FieldRow>
-                        <ReduxForm.Field
-                            component={Field}
-                            name="address"
-                            label={<strong className="u-text-semi-bold">Add a new address</strong>}
-                        >
-                            <input type="radio" checked noValidate />
-                        </ReduxForm.Field>
-                    </FieldRow>
-
-                    <FieldRow>
-                        <ReduxForm.Field component={Field} name="name" label="Full Name">
-                            <input type="text" noValidate />
-                        </ReduxForm.Field>
-                    </FieldRow>
-
-                    <FieldRow>
-                        <ReduxForm.Field
-                            component={Field}
-                            name="address-line1"
-                            label="Address"
-                            caption={!isCompanyOrAptShown && addCompanyButton}
-                        >
-                            <input type="text" noValidate />
-                        </ReduxForm.Field>
-                    </FieldRow>
-
-                    {isCompanyOrAptShown &&
-                        <FieldRow>
-                            <ReduxForm.Field
-                                component={Field}
-                                name="organization"
-                                label="Company"
-                            >
-                                <input type="text" noValidate />
-                            </ReduxForm.Field>
-
-                            <ReduxForm.Field
-                                component={Field}
-                                name="address-line2"
-                                label="Apt #, suite etc."
-                            >
-                                <input type="text" noValidate />
-                            </ReduxForm.Field>
-                        </FieldRow>
-                    }
-
-                    <FieldRow>
-                        <ReduxForm.Field component={Field} name="shipping-city" label="City">
-                            <input type="text" noValidate />
-                        </ReduxForm.Field>
-                    </FieldRow>
-
-                    <FieldRow>
-                        <ReduxForm.Field component={Field} name="shipping-country" label="Country">
-                            <select>
-                                <option>Canada</option>
-                            </select>
-                        </ReduxForm.Field>
-                    </FieldRow>
-
-                    <FieldRow>
-                        <ReduxForm.Field component={Field} name="shipping-state" label="Province">
-                            <input type="text" noValidate />
-                        </ReduxForm.Field>
-                    </FieldRow>
-
-                    <FieldRow>
-                        <ReduxForm.Field component={Field} name="shipping-postal-code" label="Postal Code">
-                            <input type="text" noValidate />
-                        </ReduxForm.Field>
-                    </FieldRow>
-
-                    <FieldRow>
-                        <ReduxForm.Field
-                            component={Field}
-                            name="home-phone"
-                            label="Phone"
-                            caption="In case we need to contact you about your order"
-                        >
-                            <input type="tel" noValidate />
-                        </ReduxForm.Field>
-                    </FieldRow>
-                </div>
-            </div>
-        </div>
-    )
-}
-
-const renderShippingMethod = () => {
-    const methodLabel = (
-        <strong className="u-flexbox u-text-semi-bold">
-            <div className="u-flex">Fixed - Flate rate</div>
-            <div className="u-flex-none">$5.00</div>
-        </strong>
-    )
-
-    return (
-        <div>
-            <div className="t-checkout-shipping__title u-padding-top-lg u-padding-bottom-lg">
-                <h2 className="u-h4">Shipping Method</h2>
-            </div>
-
-            <div className="u-padding-md u-border-light-top u-border-light-bottom u-bg-color-neutral-10">
-                <FieldRow>
-                    <ReduxForm.Field component={Field} name="shipping-method" label={methodLabel}>
-                        <input type="radio" noValidate />
-                    </ReduxForm.Field>
-                </FieldRow>
-
-                <FieldRow className="u-margin-top-lg">
-                    <Button type="submit" className="c--primary u-width-full u-text-uppercase">
-                        Continue to Payment
-                    </Button>
-                </FieldRow>
-            </div>
-        </div>
-    )
-}
+import ShippingAddressForm from './shipping-address'
+import ShippingEmail from './shipping-email'
+import ShippingMethod from './shipping-method'
 
 const CheckoutShippingForm = (props) => {
     const {
+        formTitle,
         handleShowCompanyAndApt,
         handleSubmit,
         isCompanyOrAptShown,
@@ -223,12 +21,16 @@ const CheckoutShippingForm = (props) => {
         <form className="t-checkout-shipping__form" onSubmit={handleSubmit} noValidate>
             <Grid className="u-center-piece">
                 <GridSpan tablet={{span: 6, pre: 1, post: 1}} desktop={{span: 7}}>
-                    {renderEmailAddress(onShippingEmailRecognized)}
-                    {renderShippingAddress(isCompanyOrAptShown, handleShowCompanyAndApt)}
+                    <ShippingEmail
+                        onShippingEmailRecognized={onShippingEmailRecognized} />
+                    <ShippingAddressForm
+                        formTitle={formTitle}
+                        handleShowCompanyAndApt={handleShowCompanyAndApt}
+                        isCompanyOrAptShown={isCompanyOrAptShown} />
                 </GridSpan>
 
                 <GridSpan tablet={{span: 6, pre: 1, post: 1}} desktop={{span: 5}}>
-                    {renderShippingMethod()}
+                    <ShippingMethod />
                 </GridSpan>
             </Grid>
         </form>
@@ -240,6 +42,10 @@ CheckoutShippingForm.propTypes = {
      * Whether the form is disabled or not
      */
     disabled: React.PropTypes.bool,
+    /**
+    * The title for the form
+    */
+    formTitle: React.PropTypes.string,
 
     /**
      * Shows the "Company" and "Apt #" fields

--- a/web/app/containers/checkout-shipping/partials/shipping-address.jsx
+++ b/web/app/containers/checkout-shipping/partials/shipping-address.jsx
@@ -1,0 +1,167 @@
+import React from 'react'
+import * as ReduxForm from 'redux-form'
+
+import Button from 'progressive-web-sdk/dist/components/button'
+import Field from 'progressive-web-sdk/dist/components/field'
+import FieldRow from 'progressive-web-sdk/dist/components/field-row'
+import {Icon} from 'progressive-web-sdk/dist/components/icon'
+
+
+const ShippingAddressForm = (props) => {
+    const {
+        formTitle,
+        handleShowCompanyAndApt,
+        isCompanyOrAptShown,
+    } = props
+
+    const addCompanyButton = (
+        <Button
+            className="c--is-anchor"
+            innerClassName="c--no-min-height u-padding-0"
+            onClick={handleShowCompanyAndApt}
+            >
+            <span className="u-color-brand u-text-letter-spacing-normal u-text-small">
+                Add company or apt #
+            </span>
+            <Icon name="chevron-down" className="u-margin-start-sm u-color-brand" />
+        </Button>
+    )
+    const shippingAddress = (
+        <div>
+            <p>Vancouver, BC, Canada, V4R5TS</p>
+            <p>Name: John Appleseed</p>
+        </div>
+    )
+
+    return (
+        <div>
+            <div className="t-checkout-shipping__title u-padding-top-lg u-padding-bottom-lg">
+                <h2 className="u-h4">{formTitle}</h2>
+            </div>
+
+            <div className="u-padding-md u-border-light-top u-border-light-bottom u-bg-color-neutral-10">
+                <FieldRow>
+                    <ReduxForm.Field
+                        component={Field}
+                        name="shipping-address"
+                        label={<strong className="u-text-semi-bold">725 West Georgia</strong>}
+                        caption={shippingAddress}
+                    >
+                        <input type="radio" noValidate />
+                    </ReduxForm.Field>
+                </FieldRow>
+
+                <div className="u-padding-md u-margin-top-md u-border-light">
+                    <FieldRow>
+                        <ReduxForm.Field
+                            component={Field}
+                            name="address"
+                            label={<strong className="u-text-semi-bold">Add a new address</strong>}
+                        >
+                            <input type="radio" checked noValidate />
+                        </ReduxForm.Field>
+                    </FieldRow>
+
+                    <FieldRow>
+                        <ReduxForm.Field component={Field} name="name" label="Full Name">
+                            <input type="text" noValidate />
+                        </ReduxForm.Field>
+                    </FieldRow>
+
+                    <FieldRow>
+                        <ReduxForm.Field
+                            component={Field}
+                            name="address-line1"
+                            label="Address"
+                            caption={!isCompanyOrAptShown && addCompanyButton}
+                        >
+                            <input type="text" noValidate />
+                        </ReduxForm.Field>
+                    </FieldRow>
+
+                    {isCompanyOrAptShown &&
+                        <FieldRow>
+                            <ReduxForm.Field
+                                component={Field}
+                                name="organization"
+                                label="Company"
+                            >
+                                <input type="text" noValidate />
+                            </ReduxForm.Field>
+
+                            <ReduxForm.Field
+                                component={Field}
+                                name="address-line2"
+                                label="Apt #, suite etc."
+                            >
+                                <input type="text" noValidate />
+                            </ReduxForm.Field>
+                        </FieldRow>
+                    }
+
+                    <FieldRow>
+                        <ReduxForm.Field component={Field} name="shipping-city" label="City">
+                            <input type="text" noValidate />
+                        </ReduxForm.Field>
+                    </FieldRow>
+
+                    <FieldRow>
+                        <ReduxForm.Field component={Field} name="shipping-country" label="Country">
+                            <select>
+                                <option>Canada</option>
+                            </select>
+                        </ReduxForm.Field>
+                    </FieldRow>
+
+                    <FieldRow>
+                        <ReduxForm.Field component={Field} name="shipping-state" label="Province">
+                            <input type="text" noValidate />
+                        </ReduxForm.Field>
+                    </FieldRow>
+
+                    <FieldRow>
+                        <ReduxForm.Field component={Field} name="shipping-postal-code" label="Postal Code">
+                            <input type="text" noValidate />
+                        </ReduxForm.Field>
+                    </FieldRow>
+
+                    <FieldRow>
+                        <ReduxForm.Field
+                            component={Field}
+                            name="home-phone"
+                            label="Phone"
+                            caption="In case we need to contact you about your order"
+                        >
+                            <input type="tel" noValidate />
+                        </ReduxForm.Field>
+                    </FieldRow>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+ShippingAddressForm.propTypes = {
+    /**
+     * Whether the form is disabled or not
+     */
+    disabled: React.PropTypes.bool,
+    /**
+    * The title for the form
+    */
+    formTitle: React.PropTypes.string,
+
+    /**
+     * Shows the "Company" and "Apt #" fields
+     */
+    handleShowCompanyAndApt: React.PropTypes.func,
+
+    /**
+     * Whether the "Company" and "Apt #" fields display
+     */
+    isCompanyOrAptShown: React.PropTypes.bool,
+}
+
+
+
+export default ShippingAddressForm

--- a/web/app/containers/checkout-shipping/partials/shipping-address.jsx
+++ b/web/app/containers/checkout-shipping/partials/shipping-address.jsx
@@ -7,12 +7,11 @@ import FieldRow from 'progressive-web-sdk/dist/components/field-row'
 import {Icon} from 'progressive-web-sdk/dist/components/icon'
 
 
-const ShippingAddressForm = (props) => {
-    const {
-        formTitle,
-        handleShowCompanyAndApt,
-        isCompanyOrAptShown,
-    } = props
+const ShippingAddressForm = ({
+    formTitle,
+    handleShowCompanyAndApt,
+    isCompanyOrAptShown,
+}) => {
 
     const addCompanyButton = (
         <Button

--- a/web/app/containers/checkout-shipping/partials/shipping-email.jsx
+++ b/web/app/containers/checkout-shipping/partials/shipping-email.jsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import * as ReduxForm from 'redux-form'
+
+import Button from 'progressive-web-sdk/dist/components/button'
+import Field from 'progressive-web-sdk/dist/components/field'
+import FieldRow from 'progressive-web-sdk/dist/components/field-row'
+import {Icon} from 'progressive-web-sdk/dist/components/icon'
+import Link from 'progressive-web-sdk/dist/components/link'
+
+
+const ShippingEmail = (props) => {
+    const {
+        onShippingEmailRecognized
+    } = props
+
+    const passwordHint = (
+        <Link className="u-color-brand" href="/customer/account/forgotpassword/">
+            Forgot password
+        </Link>
+    )
+    const isSigningIn = true
+
+    return (
+        <div>
+            <div className="t-checkout-shipping__email-title" />
+
+            <div className="u-padding-md u-border-light-top u-border-light-bottom u-bg-color-neutral-10">
+                <FieldRow>
+                    <ReduxForm.Field component={Field} className="pw--overlayed-hint" name="email" label="Email my receipt to">
+                        <input type="email" noValidate />
+                    </ReduxForm.Field>
+                </FieldRow>
+
+                {isSigningIn &&
+                    <FieldRow>
+                        <ReduxForm.Field component={Field} name="password" label="Password" hint={passwordHint}>
+                            <input type="password" noValidate />
+                        </ReduxForm.Field>
+                    </FieldRow>
+                }
+
+                {isSigningIn &&
+                    <FieldRow>
+                        <Button
+                            className="c--secondary u-width-full u-text-uppercase"
+                            onClick={onShippingEmailRecognized}>
+                            <Icon name="user" className="u-margin-end" />
+                            Sign In
+                        </Button>
+                    </FieldRow>
+                }
+            </div>
+        </div>
+    )
+}
+
+ShippingEmail.propTypes = {
+    /**
+     * Whether the form is disabled or not
+     */
+    onShippingEmailRecognized: React.PropTypes.function
+}
+
+
+
+export default ShippingEmail

--- a/web/app/containers/checkout-shipping/partials/shipping-email.jsx
+++ b/web/app/containers/checkout-shipping/partials/shipping-email.jsx
@@ -58,7 +58,7 @@ ShippingEmail.propTypes = {
     /**
      * Whether the form is disabled or not
      */
-    onShippingEmailRecognized: React.PropTypes.function
+    onShippingEmailRecognized: React.PropTypes.func
 }
 
 

--- a/web/app/containers/checkout-shipping/partials/shipping-email.jsx
+++ b/web/app/containers/checkout-shipping/partials/shipping-email.jsx
@@ -8,10 +8,7 @@ import {Icon} from 'progressive-web-sdk/dist/components/icon'
 import Link from 'progressive-web-sdk/dist/components/link'
 
 
-const ShippingEmail = (props) => {
-    const {
-        onShippingEmailRecognized
-    } = props
+const ShippingEmail = ({onShippingEmailRecognized}) => {
 
     const passwordHint = (
         <Link className="u-color-brand" href="/customer/account/forgotpassword/">

--- a/web/app/containers/checkout-shipping/partials/shipping-method.jsx
+++ b/web/app/containers/checkout-shipping/partials/shipping-method.jsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import * as ReduxForm from 'redux-form'
+
+import Button from 'progressive-web-sdk/dist/components/button'
+import Field from 'progressive-web-sdk/dist/components/field'
+import FieldRow from 'progressive-web-sdk/dist/components/field-row'
+
+const ShippingMethod = () => {
+    const methodLabel = (
+        <strong className="u-flexbox u-text-semi-bold">
+            <div className="u-flex">Fixed - Flate rate</div>
+            <div className="u-flex-none">$5.00</div>
+        </strong>
+    )
+
+    return (
+        <div>
+            <div className="t-checkout-shipping__title u-padding-top-lg u-padding-bottom-lg">
+                <h2 className="u-h4">Shipping Method</h2>
+            </div>
+
+            <div className="u-padding-md u-border-light-top u-border-light-bottom u-bg-color-neutral-10">
+                <FieldRow>
+                    <ReduxForm.Field component={Field} name="shipping-method" label={methodLabel}>
+                        <input type="radio" noValidate />
+                    </ReduxForm.Field>
+                </FieldRow>
+
+                <FieldRow className="u-margin-top-lg">
+                    <Button type="submit" className="c--primary u-width-full u-text-uppercase">
+                        Continue to Payment
+                    </Button>
+                </FieldRow>
+            </div>
+        </div>
+    )
+}
+
+ShippingMethod.propTypes = {
+}
+
+
+
+export default ShippingMethod

--- a/web/app/containers/checkout-shipping/reducer.js
+++ b/web/app/containers/checkout-shipping/reducer.js
@@ -1,18 +1,11 @@
 import {handleActions} from 'redux-actions'
 import Immutable from 'immutable'
-import * as checkoutShippingActions from './actions'
-
-const initialState = Immutable.fromJS({
-    body: '',
-    contentsLoaded: true,
-    isCompanyOrAptShown: false,
-})
+import {mergePayloadForActions} from '../../utils/reducer-utils'
+import {receiveData, showCompanyAndApt} from './actions'
 
 export default handleActions({
-    [checkoutShippingActions.receiveContents]: (state, {payload}) => {
-        return state.mergeDeep(payload, {contentsLoaded: true})
-    },
-    [checkoutShippingActions.showCompanyAndApt]: (state) => {
+    ...mergePayloadForActions(receiveData),
+    [showCompanyAndApt]: (state) => {
         return state.merge({isCompanyOrAptShown: true})
     }
-}, initialState)
+}, Immutable.Map())

--- a/web/app/containers/checkout-shipping/reducer.test.js
+++ b/web/app/containers/checkout-shipping/reducer.test.js
@@ -16,21 +16,6 @@ test('unknown action type leaves state unchanged', () => {
     expect(reducer(inputState, action)).toEqual(inputState)
 })
 
-test('checkoutShippingActions.receiveData sets contentsLoaded flag', () => {
-    const action = receiveData({})
-
-    const initialState = Map({
-        contentsLoaded: false,
-        bystander: 'data'
-    })
-
-    const finalState = Map({
-        contentsLoaded: true,
-        bystander: 'data'
-    })
-
-    expect(reducer(initialState, action).equals(finalState)).toBe(true)
-})
 
 test('checkoutShippingActions.showCompanyAndApt sets isCompanyOrAptShown flag', () => {
     const action = showCompanyAndApt({})

--- a/web/app/containers/checkout-shipping/reducer.test.js
+++ b/web/app/containers/checkout-shipping/reducer.test.js
@@ -2,7 +2,7 @@
 import {Map} from 'immutable'
 
 import reducer from './reducer'
-import {receiveContents, showCompanyAndApt} from './actions'
+import {receiveData, showCompanyAndApt} from './actions'
 
 test('unknown action type leaves state unchanged', () => {
     const action = {
@@ -16,8 +16,8 @@ test('unknown action type leaves state unchanged', () => {
     expect(reducer(inputState, action)).toEqual(inputState)
 })
 
-test('checkoutShippingActions.receiveContents sets contentsLoaded flag', () => {
-    const action = receiveContents({})
+test('checkoutShippingActions.receiveData sets contentsLoaded flag', () => {
+    const action = receiveData({})
 
     const initialState = Map({
         contentsLoaded: false,

--- a/web/app/containers/footer/parsers/parser.js
+++ b/web/app/containers/footer/parsers/parser.js
@@ -2,9 +2,12 @@ import {parseTextLink} from '../../../utils/parser-utils'
 
 export const parseNewsLetter = ($content) => {
     const $form = $content.find('footer .form.subscribe')
-    const method = $form.attr('method').toLowerCase()
+    const method = $form.attr('method')
     const action = $form.attr('action')
-    return {action, method}
+    return {
+        action,
+        method: method ? method.toLowerCase() : ''
+    }
 }
 
 const FOOTER_LINK_SELECTOR = 'footer .footer.links li a'

--- a/web/app/loader-routes.js
+++ b/web/app/loader-routes.js
@@ -1,4 +1,4 @@
 /* eslint-disable */
 // GENERATED FILE DO NOT EDIT
-const routes = [/^\/\/?$/,/^\/checkout\/cart\/?$/,/^\/customer\/account\/login\/?$/,/^\/customer\/account\/create\/?$/,/^\/potions\.html\/?$/,/^\/books\.html\/?$/,/^\/ingredients\.html\/?$/,/^\/supplies\.html\/?$/,/^\/new-arrivals\.html\/?$/,/^\/charms\.html\/?$/,/^\/.*?\.html\/?$/,/^\/checkout\/shipping\/?$/,/^\/checkout\/payment\/?$/,/^\/checkout\/confirmation\/?$/]
+const routes = [/^\/\/?$/,/^\/checkout\/cart\/?$/,/^\/customer\/account\/login\/?$/,/^\/customer\/account\/create\/?$/,/^\/potions\.html\/?$/,/^\/books\.html\/?$/,/^\/ingredients\.html\/?$/,/^\/supplies\.html\/?$/,/^\/new-arrivals\.html\/?$/,/^\/charms\.html\/?$/,/^\/.*?\.html\/?$/,/^\/checkout\/?$/,/^\/checkout\/payment\/?$/,/^\/checkout\/confirmation\/?$/]
 export default routes


### PR DESCRIPTION
This PR is some initial work related to moving the checkout shipping page over to the new Architecture. 

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1111
 **Linked PRs**: n/a (larger PR will be opened for architecture-2.0-checkout-shipping)

## Changes
- Update shipping page route so we can fetch the page content the same as we do on other pages
- Fixed JS error in the footer on checkout pages
- Parse and render the form title from the desktop HTML
- Refactored shipping sections into their own partials

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- add an item to your cart
- navigate to: https://www.merlinspotions.com/checkout/
- the still renders the same
