### PR TITLE
Connect checkout shipping partials

### DIFF
--- a/web/app/containers/checkout-shipping/actions.test.js
+++ b/web/app/containers/checkout-shipping/actions.test.js
@@ -11,26 +11,13 @@ afterAll(() => {
     global.fetch = realFetch
 })
 
-jest.mock('progressive-web-sdk/dist/jquery-response')
-import {jqueryResponse} from 'progressive-web-sdk/dist/jquery-response'
 jest.mock('./checkout-shipping-parser')
 import checkoutShippingParser from './checkout-shipping-parser'
 
 
 test('process parses the response and dispatches receiveData', () => {
-    jqueryResponse.mockClear()
-    jqueryResponse.mockReturnValue(Promise.resolve(['$', '$response']))
 
-    const thunk = process('page contents!')
-    expect(typeof thunk).toBe('function')
-
-    const mockDispatch = jest.fn()
-
-    return thunk(mockDispatch)
-        .then(() => {
-            expect(jqueryResponse).toBeCalledWith('page contents!')
-
-            expect(mockDispatch).toBeCalled()
-            expect(checkoutShippingParser).toBeCalledWith('$', '$response')
-        })
+    const thunk = process({payload: {$: '$', $response: '$response'}})
+    expect(typeof thunk).toBe('object')
+    expect(checkoutShippingParser).toBeCalledWith('$', '$response')
 })

--- a/web/app/containers/checkout-shipping/container.jsx
+++ b/web/app/containers/checkout-shipping/container.jsx
@@ -45,12 +45,7 @@ class CheckoutShipping extends React.Component {
                     </div>
                 </div>
 
-                <CheckoutShippingReduxForm
-                    formTitle={formTitle}
-                    isCompanyOrAptShown={isCompanyOrAptShown}
-                    handleShowCompanyAndApt={this.handleShowCompanyAndApt}
-                    onShippingEmailRecognized={onShippingEmailRecognized}
-                />
+                <CheckoutShippingReduxForm />
             </div>
         )
     }

--- a/web/app/containers/checkout-shipping/container.jsx
+++ b/web/app/containers/checkout-shipping/container.jsx
@@ -1,75 +1,29 @@
-import React, {PropTypes} from 'react'
-import {connect} from 'react-redux'
-import Immutable from 'immutable'
+import React from 'react'
 import classNames from 'classnames'
 
-import * as checkoutShippingActions from './actions'
 import CheckoutShippingReduxForm from './partials/checkout-shipping-form'
 import {ProgressSteps, ProgressStepsItem} from 'progressive-web-sdk/dist/components/progress-steps'
 
 
-class CheckoutShipping extends React.Component {
-    constructor(props) {
-        super(props)
+const CheckoutShipping = () => {
+    const templateClassnames = classNames('t-checkout-shipping u-bg-color-neutral-20 t--loaded')
 
-        this.handleShowCompanyAndApt = this.handleShowCompanyAndApt.bind(this)
-    }
-
-    shouldComponentUpdate(newProps) {
-        return !Immutable.is(this.props.checkoutShipping, newProps.checkoutShipping)
-    }
-
-    handleShowCompanyAndApt() {
-        this.props.showCompanyAndApt()
-    }
-
-    render() {
-        const {
-            isCompanyOrAptShown,
-            formTitle
-        } = this.props.checkoutShipping.toJS()
-        const {onShippingEmailRecognized} = this.props
-
-        const templateClassnames = classNames('t-checkout-shipping u-bg-color-neutral-20 t--loaded')
-
-        return (
-            <div className={templateClassnames}>
-                <div className="u-bg-color-neutral-10 u-border-light-bottom">
-                    <div className="t-checkout-shipping__progress">
-                        <ProgressSteps>
-                            <ProgressStepsItem icon="cart-full" title="Cart" href="#" />
-                            <ProgressStepsItem icon="shipping" title="Shipping" current />
-                            <ProgressStepsItem icon="payment-full" title="Payment" />
-                            <ProgressStepsItem icon="done" title="Done" />
-                        </ProgressSteps>
-                    </div>
+    return (
+        <div className={templateClassnames}>
+            <div className="u-bg-color-neutral-10 u-border-light-bottom">
+                <div className="t-checkout-shipping__progress">
+                    <ProgressSteps>
+                        <ProgressStepsItem icon="cart-full" title="Cart" href="#" />
+                        <ProgressStepsItem icon="shipping" title="Shipping" current />
+                        <ProgressStepsItem icon="payment-full" title="Payment" />
+                        <ProgressStepsItem icon="done" title="Done" />
+                    </ProgressSteps>
                 </div>
-
-                <CheckoutShippingReduxForm />
             </div>
-        )
-    }
+
+            <CheckoutShippingReduxForm />
+        </div>
+    )
 }
 
-CheckoutShipping.propTypes = {
-    checkoutShipping: PropTypes.instanceOf(Immutable.Map),
-    showCompanyAndApt: PropTypes.func,
-
-    onShippingEmailRecognized: PropTypes.func,
-}
-
-const mapStateToProps = (state) => {
-    return {
-        checkoutShipping: state.ui.checkoutShipping
-    }
-}
-
-const mapDispatchToProps = {
-    showCompanyAndApt: checkoutShippingActions.showCompanyAndApt,
-    onShippingEmailRecognized: checkoutShippingActions.onShippingEmailRecognized,
-}
-
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps
-)(CheckoutShipping)
+export default CheckoutShipping

--- a/web/app/containers/checkout-shipping/partials/checkout-shipping-form.jsx
+++ b/web/app/containers/checkout-shipping/partials/checkout-shipping-form.jsx
@@ -9,7 +9,6 @@ import ShippingMethod from './shipping-method'
 
 const CheckoutShippingForm = ({
     handleSubmit,
-    onShippingEmailRecognized,
     // disabled,
     // submitting
 }) => {
@@ -37,26 +36,13 @@ CheckoutShippingForm.propTypes = {
     disabled: React.PropTypes.bool,
 
     /**
-     * Shows the "Company" and "Apt #" fields
-     */
-    handleShowCompanyAndApt: React.PropTypes.func,
-
-    /**
      * Redux-form internal
      */
     handleSubmit: React.PropTypes.func,
-
-    /**
-     * Whether the "Company" and "Apt #" fields display
-     */
-    isCompanyOrAptShown: React.PropTypes.bool,
-
     /**
      * Redux-form internal
      */
     submitting: React.PropTypes.bool,
-
-    onShippingEmailRecognized: React.PropTypes.func,
 }
 
 const validate = (values) => {

--- a/web/app/containers/checkout-shipping/partials/checkout-shipping-form.jsx
+++ b/web/app/containers/checkout-shipping/partials/checkout-shipping-form.jsx
@@ -18,8 +18,7 @@ const CheckoutShippingForm = ({
         <form className="t-checkout-shipping__form" onSubmit={handleSubmit} noValidate>
             <Grid className="u-center-piece">
                 <GridSpan tablet={{span: 6, pre: 1, post: 1}} desktop={{span: 7}}>
-                    <ShippingEmail
-                        onShippingEmailRecognized={onShippingEmailRecognized} />
+                    <ShippingEmail />
                     <ShippingAddressForm />
                 </GridSpan>
 

--- a/web/app/containers/checkout-shipping/partials/checkout-shipping-form.jsx
+++ b/web/app/containers/checkout-shipping/partials/checkout-shipping-form.jsx
@@ -1,16 +1,14 @@
 import React from 'react'
 import * as ReduxForm from 'redux-form'
 
+
 import {Grid, GridSpan} from '../../../components/grid'
 import ShippingAddressForm from './shipping-address'
 import ShippingEmail from './shipping-email'
 import ShippingMethod from './shipping-method'
 
 const CheckoutShippingForm = ({
-    formTitle,
-    handleShowCompanyAndApt,
     handleSubmit,
-    isCompanyOrAptShown,
     onShippingEmailRecognized,
     // disabled,
     // submitting
@@ -22,10 +20,7 @@ const CheckoutShippingForm = ({
                 <GridSpan tablet={{span: 6, pre: 1, post: 1}} desktop={{span: 7}}>
                     <ShippingEmail
                         onShippingEmailRecognized={onShippingEmailRecognized} />
-                    <ShippingAddressForm
-                        formTitle={formTitle}
-                        handleShowCompanyAndApt={handleShowCompanyAndApt}
-                        isCompanyOrAptShown={isCompanyOrAptShown} />
+                    <ShippingAddressForm />
                 </GridSpan>
 
                 <GridSpan tablet={{span: 6, pre: 1, post: 1}} desktop={{span: 5}}>
@@ -41,10 +36,6 @@ CheckoutShippingForm.propTypes = {
      * Whether the form is disabled or not
      */
     disabled: React.PropTypes.bool,
-    /**
-    * The title for the form
-    */
-    formTitle: React.PropTypes.string,
 
     /**
      * Shows the "Company" and "Apt #" fields
@@ -76,6 +67,7 @@ const validate = (values) => {
     }
     return errors
 }
+
 
 const CheckoutShippingReduxForm = ReduxForm.reduxForm({
     form: 'shippingForm',

--- a/web/app/containers/checkout-shipping/partials/shipping-address.jsx
+++ b/web/app/containers/checkout-shipping/partials/shipping-address.jsx
@@ -1,5 +1,8 @@
 import React from 'react'
+import {connect} from 'react-redux'
 import * as ReduxForm from 'redux-form'
+
+import {showCompanyAndApt} from '../actions'
 
 import Button from 'progressive-web-sdk/dist/components/button'
 import Field from 'progressive-web-sdk/dist/components/field'
@@ -161,6 +164,21 @@ ShippingAddressForm.propTypes = {
     isCompanyOrAptShown: React.PropTypes.bool,
 }
 
+const mapStateToProps = (state) => {
+    const checkoutShippingData = state.ui.checkoutShipping
+    return {
+        formTitle: checkoutShippingData.get('formTitle'),
+        isCompanyOrAptShown: checkoutShippingData.get('isCompanyOrAptShown')
+    }
+}
+
+const mapDispatchToProps = {
+    handleShowCompanyAndApt: showCompanyAndApt,
+}
 
 
-export default ShippingAddressForm
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(ShippingAddressForm)

--- a/web/app/containers/checkout-shipping/partials/shipping-email.jsx
+++ b/web/app/containers/checkout-shipping/partials/shipping-email.jsx
@@ -1,5 +1,8 @@
 import React from 'react'
+import {connect} from 'react-redux'
 import * as ReduxForm from 'redux-form'
+
+import {onShippingEmailRecognized} from '../actions'
 
 import Button from 'progressive-web-sdk/dist/components/button'
 import Field from 'progressive-web-sdk/dist/components/field'
@@ -58,6 +61,14 @@ ShippingEmail.propTypes = {
     onShippingEmailRecognized: React.PropTypes.func
 }
 
+const mapStateToProps = (state) => {
+    // No content from the state is currently needed for this partial
+    return {}
+}
+
+const mapDispatchToProps = {
+    onShippingEmailRecognized
+}
 
 
-export default ShippingEmail
+export default connect(mapStateToProps, mapDispatchToProps)(ShippingEmail)

--- a/web/app/containers/checkout-shipping/partials/shipping-method.jsx
+++ b/web/app/containers/checkout-shipping/partials/shipping-method.jsx
@@ -39,6 +39,4 @@ const ShippingMethod = () => {
 ShippingMethod.propTypes = {
 }
 
-
-
 export default ShippingMethod

--- a/web/app/containers/checkout-shipping/reducer.test.js
+++ b/web/app/containers/checkout-shipping/reducer.test.js
@@ -2,7 +2,7 @@
 import {Map} from 'immutable'
 
 import reducer from './reducer'
-import {receiveData, showCompanyAndApt} from './actions'
+import {showCompanyAndApt} from './actions'
 
 test('unknown action type leaves state unchanged', () => {
     const action = {


### PR DESCRIPTION
This PR disconnects the main checkout shipping container from the store, and instead connects partials to the store. **Note:** Selectors have not yet been added for this container, they will be added in a separate PR. 

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1111
 **Linked PRs**: #292 

## Changes
- Connect shipping-email and shipping-address partials to the redux store
- Disconnect checkout-shipping main container from the store

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- add an item to your cart
- navigate to: https://www.merlinspotions.com/checkout/
- confirm that the page still works the same as it did before
