### PR TITLE
Astro: Merlins Remove web header in checkout

### DIFF
--- a/web/app/containers/checkout-header/container.js
+++ b/web/app/containers/checkout-header/container.js
@@ -3,34 +3,39 @@ import React from 'react'
 import Button from 'progressive-web-sdk/dist/components/button'
 import {HeaderBar, HeaderBarTitle} from 'progressive-web-sdk/dist/components/header-bar'
 import {Icon} from 'progressive-web-sdk/dist/components/icon'
+import {isRunningInAstro} from '../../utils/astro-integration'
 
 const CheckoutHeader = function(props) {
     const canSignIn = true
-    return (
-        <header className="t-checkout-header">
-            <HeaderBar className="t-checkout-header__bar">
-                <HeaderBarTitle className="u-flex-none u-padding-start u-text-align-start">
-                    <h2 className="t-checkout-header__title u-heading-family u-text-uppercase">
-                        <span className="u-text-lighter">MERLIN'S</span> CHECKOUT
-                    </h2>
-                </HeaderBarTitle>
+    if (isRunningInAstro) {
+        return null
+    } else {
+        return (
+            <header className="t-checkout-header">
+                <HeaderBar className="t-checkout-header__bar">
+                    <HeaderBarTitle className="u-flex-none u-padding-start u-text-align-start">
+                        <h2 className="t-checkout-header__title u-heading-family u-text-uppercase">
+                            <span className="u-text-lighter">MERLIN'S</span> CHECKOUT
+                        </h2>
+                    </HeaderBarTitle>
 
-                <Icon name="lock" size="medium" className="u-flex-none" />
+                    <Icon name="lock" size="medium" className="u-flex-none" />
 
-                {canSignIn &&
-                    <div className="u-flex u-text-align-end">
-                        <Button
-                            href="/customer/account/login/"
-                            innerClassName="u-color-neutral-10"
-                        >
-                            <Icon name="user" className="u-margin-end-sm" />
-                            <span>Sign in</span>
-                        </Button>
-                    </div>
-                }
-            </HeaderBar>
-        </header>
-    )
+                    {canSignIn &&
+                        <div className="u-flex u-text-align-end">
+                            <Button
+                                href="/customer/account/login/"
+                                innerClassName="u-color-neutral-10"
+                            >
+                                <Icon name="user" className="u-margin-end-sm" />
+                                <span>Sign in</span>
+                            </Button>
+                        </div>
+                    }
+                </HeaderBar>
+            </header>
+        )
+    }
 }
 
 export default CheckoutHeader

--- a/web/app/containers/checkout-header/container.js
+++ b/web/app/containers/checkout-header/container.js
@@ -7,33 +7,35 @@ import {isRunningInAstro} from '../../utils/astro-integration'
 
 const CheckoutHeader = function(props) {
     const canSignIn = true
-        return (
+    return (
+        <div>
             {!isRunningInAstro &&
-                <header className="t-checkout-header">
-                    <HeaderBar className="t-checkout-header__bar">
-                        <HeaderBarTitle className="u-flex-none u-padding-start u-text-align-start">
-                            <h2 className="t-checkout-header__title u-heading-family u-text-uppercase">
-                                <span className="u-text-lighter">MERLIN'S</span> CHECKOUT
-                            </h2>
-                        </HeaderBarTitle>
+            <header className="t-checkout-header">
+                <HeaderBar className="t-checkout-header__bar">
+                    <HeaderBarTitle className="u-flex-none u-padding-start u-text-align-start">
+                        <h2 className="t-checkout-header__title u-heading-family u-text-uppercase">
+                            <span className="u-text-lighter">MERLIN'S</span> CHECKOUT
+                                </h2>
+                    </HeaderBarTitle>
 
-                        <Icon name="lock" size="medium" className="u-flex-none" />
+                    <Icon name="lock" size="medium" className="u-flex-none" />
 
-                        {canSignIn &&
-                            <div className="u-flex u-text-align-end">
-                                <Button
-                                    href="/customer/account/login/"
-                                    innerClassName="u-color-neutral-10"
-                                >
-                                    <Icon name="user" className="u-margin-end-sm" />
-                                    <span>Sign in</span>
-                                </Button>
-                            </div>
-                        }
-                    </HeaderBar>
-                </header>
-            }
-        )
+                    {canSignIn &&
+                    <div className="u-flex u-text-align-end">
+                        <Button
+                            href="/customer/account/login/"
+                            innerClassName="u-color-neutral-10"
+                                    >
+                            <Icon name="user" className="u-margin-end-sm" />
+                            <span>Sign in</span>
+                        </Button>
+                    </div>
+                            }
+                </HeaderBar>
+            </header>
+                }
+        </div>
+    )
 }
 
 export default CheckoutHeader

--- a/web/app/containers/checkout-header/container.js
+++ b/web/app/containers/checkout-header/container.js
@@ -7,35 +7,33 @@ import {isRunningInAstro} from '../../utils/astro-integration'
 
 const CheckoutHeader = function(props) {
     const canSignIn = true
-    if (isRunningInAstro) {
-        return null
-    } else {
         return (
-            <header className="t-checkout-header">
-                <HeaderBar className="t-checkout-header__bar">
-                    <HeaderBarTitle className="u-flex-none u-padding-start u-text-align-start">
-                        <h2 className="t-checkout-header__title u-heading-family u-text-uppercase">
-                            <span className="u-text-lighter">MERLIN'S</span> CHECKOUT
-                        </h2>
-                    </HeaderBarTitle>
+            {!isRunningInAstro &&
+                <header className="t-checkout-header">
+                    <HeaderBar className="t-checkout-header__bar">
+                        <HeaderBarTitle className="u-flex-none u-padding-start u-text-align-start">
+                            <h2 className="t-checkout-header__title u-heading-family u-text-uppercase">
+                                <span className="u-text-lighter">MERLIN'S</span> CHECKOUT
+                            </h2>
+                        </HeaderBarTitle>
 
-                    <Icon name="lock" size="medium" className="u-flex-none" />
+                        <Icon name="lock" size="medium" className="u-flex-none" />
 
-                    {canSignIn &&
-                        <div className="u-flex u-text-align-end">
-                            <Button
-                                href="/customer/account/login/"
-                                innerClassName="u-color-neutral-10"
-                            >
-                                <Icon name="user" className="u-margin-end-sm" />
-                                <span>Sign in</span>
-                            </Button>
-                        </div>
-                    }
-                </HeaderBar>
-            </header>
+                        {canSignIn &&
+                            <div className="u-flex u-text-align-end">
+                                <Button
+                                    href="/customer/account/login/"
+                                    innerClassName="u-color-neutral-10"
+                                >
+                                    <Icon name="user" className="u-margin-end-sm" />
+                                    <span>Sign in</span>
+                                </Button>
+                            </div>
+                        }
+                    </HeaderBar>
+                </header>
+            }
         )
-    }
 }
 
 export default CheckoutHeader


### PR DESCRIPTION
This removes default web header in the checkout flow. This is to match the looks of 
http://merlins-app.surge.sh/#artboard1

 **JIRA**:  https://mobify.atlassian.net/browse/HYB-985
 **Linked PRs**: #301

## Changes
- if runninh in Astro return null else return header
## How to test-drive this PR
- add an item to cart
- open the checkout modal
- press proceed to checkout
- on the top you shouldn't see a web header, you should see the checkout flow icons at the top
