### PR TITLE
Persist shipping data

### DIFF
--- a/web/app/containers/checkout-shipping/actions.js
+++ b/web/app/containers/checkout-shipping/actions.js
@@ -7,7 +7,7 @@ import {addNotification, fetchPage, removeAllNotifications, removeNotification} 
 import {getCustomerEntityID} from './selectors'
 import {getIsLoggedIn} from '../app/selectors'
 import {getShippingFormValues} from '../../store/form/selectors'
-import {receiveShippingMethodInitialValues} from '../../store/checkout/actions'
+import {receiveShippingMethodInitialValues, receiveCheckoutData} from '../../store/checkout/actions'
 
 import {makeJsonEncodedRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
 
@@ -130,7 +130,7 @@ export const submitShipping = () => {
         const isLoggedIn = getIsLoggedIn(currentState)
         const names = name.split(' ')
         const shippingSelections = shipping_method.split('_')
-        const addressData = {
+        const address = {
             firstname: names.slice(0, -1).join(' '),
             lastname: names.slice(-1).join(' '),
             company: company || '',
@@ -144,9 +144,9 @@ export const submitShipping = () => {
         }
         const addressInformation = {
             addressInformation: {
-                shippingAddress: addressData,
+                shippingAddress: address,
                 billingAddress: {
-                    ...addressData,
+                    ...address,
                     saveInAddressBook: false
                 },
                 shipping_carrier_code: shippingSelections[0],
@@ -154,6 +154,7 @@ export const submitShipping = () => {
             }
         }
         const persistShippingURL = `https://www.merlinspotions.com/rest/default/V1/${isLoggedIn ? 'carts/mine' : `guest-carts/${entityID}`}/shipping-information`
+        dispatch(receiveCheckoutData({shipping: {address}}))
         makeJsonEncodedRequest(persistShippingURL, addressInformation, {method: 'POST'})
             .then((response) => response.json())
             .then((responseJSON) => {

--- a/web/app/store/checkout/shipping/selectors.js
+++ b/web/app/store/checkout/shipping/selectors.js
@@ -5,3 +5,5 @@ import {getCheckout} from '../../selectors'
 export const getShipping = createGetSelector(getCheckout, 'shipping', Immutable.Map())
 
 export const getShippingInitialValues = createGetSelector(getShipping, 'initialValues')
+
+export const getShippingAddress = createGetSelector(getShipping, 'address')

--- a/web/app/store/checkout/shipping/selectors.js
+++ b/web/app/store/checkout/shipping/selectors.js
@@ -1,3 +1,4 @@
+import {createSelector} from 'reselect'
 import Immutable from 'immutable'
 import {createGetSelector} from '../../../utils/selector-utils'
 import {getCheckout} from '../../selectors'
@@ -7,3 +8,25 @@ export const getShipping = createGetSelector(getCheckout, 'shipping', Immutable.
 export const getShippingInitialValues = createGetSelector(getShipping, 'initialValues')
 
 export const getShippingAddress = createGetSelector(getShipping, 'address')
+
+export const getShippingFirstName = createGetSelector(getShippingAddress, 'firstname', '')
+
+export const getShippingLastName = createGetSelector(getShippingAddress, 'lastname', '')
+
+export const getShippingFullName = createSelector(getShippingFirstName, getShippingLastName, (firstName, lastName) => `${firstName} ${lastName}`)
+
+export const getStreet = createGetSelector(getShippingAddress, 'street', Immutable.List())
+
+export const getStreetLineOne = createSelector(getStreet, (street) => { return street.size ? street.get(0) : '' })
+
+export const getStreetLineTwo = createSelector(getStreet, (street) => { return street.size ? street.get(1) : '' })
+
+export const getTelephone = createGetSelector(getShippingAddress, 'telephone')
+
+export const getPostcode = createGetSelector(getShippingAddress, 'postcode')
+
+export const getCompany = createGetSelector(getShippingAddress, 'company')
+
+export const getRegionId = createGetSelector(getShippingAddress, 'regionId')
+
+export const getCountryId = createGetSelector(getShippingAddress, 'countryId')


### PR DESCRIPTION
This PR adds the shipping data entered in the shipping form to the store under checkout -> shipping -> address. The data uses the same format that the form submission requires. 

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1111
 **Linked PRs**: n/a

## Changes
- Added shipping data to the store under checkout -> shipping -> address
- Added selectors to access the address data

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- add an item to the cart
- navigate to: https://www.merlinspotions.com/checkout/
- confirm that the page still works as expected
