### PR TITLE
Adds bundle analyzer to the scaffold

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## To be released
+- Add option to analyze bundle after build. Set `MOBIFY_ANALYZE` environment variable to `true` before running any build. Eg. `MOBIFY_ANALYZE=true npm run prod:build`
+
 ## 0.11.0 (February 10, 2017)
 - Upgrade to the latest SDK
 - Get new generators to match the architecture 2.0

--- a/web/package.json
+++ b/web/package.json
@@ -89,7 +89,7 @@
     "text-loader": "0.0.1",
     "validator": "6.2.0",
     "webpack": "2.2.0",
-    "webpack-bundle-analyzer": "^2.3.0",
+    "webpack-bundle-analyzer": "2.3.0",
     "webpack-dev-server": "1.16.2",
     "webpack-hot-middleware": "2.13.0"
   },

--- a/web/package.json
+++ b/web/package.json
@@ -89,6 +89,7 @@
     "text-loader": "0.0.1",
     "validator": "6.2.0",
     "webpack": "2.2.0",
+    "webpack-bundle-analyzer": "^2.3.0",
     "webpack-dev-server": "1.16.2",
     "webpack-hot-middleware": "2.13.0"
   },

--- a/web/webpack/base.main.js
+++ b/web/webpack/base.main.js
@@ -6,9 +6,9 @@ const path = require('path')
 const baseCommon = require('./base.common')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const CopyPlugin = require('copy-webpack-plugin')
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
 
-const analyzeBundle = process.env.MOBIFY_ANALYZE === 'true';
+const analyzeBundle = process.env.MOBIFY_ANALYZE === 'true'
 
 const config = {
     devtool: 'cheap-source-map',
@@ -66,12 +66,12 @@ const config = {
 
 if (analyzeBundle) {
     console.info('Analyzing build...')
-	config.plugins = config.plugins.concat([
+    config.plugins = config.plugins.concat([
         new BundleAnalyzerPlugin({
             analyzerMode: 'static',
             openAnalyzer: true
         })
-    ]);
+    ])
 }
 
 module.exports = config

--- a/web/webpack/base.main.js
+++ b/web/webpack/base.main.js
@@ -6,8 +6,11 @@ const path = require('path')
 const baseCommon = require('./base.common')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const CopyPlugin = require('copy-webpack-plugin')
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
-module.exports = {
+const analyzeBundle = process.env.MOBIFY_ANALYZE === 'true';
+
+const config = {
     devtool: 'cheap-source-map',
     entry: [
         'whatwg-fetch',
@@ -60,3 +63,15 @@ module.exports = {
         ],
     }
 }
+
+if (analyzeBundle) {
+    console.info('Analyzing build...')
+	config.plugins = config.plugins.concat([
+        new BundleAnalyzerPlugin({
+            analyzerMode: 'static',
+            openAnalyzer: true
+        })
+    ]);
+}
+
+module.exports = config


### PR DESCRIPTION
This PR adds the ability to analyze the build output. It is controlled using the `MOBIFY_ANALYZE` environment variable. 

 **JIRA**: N/A
 **Linked PRs**: N/A

## Changes
- Adds the webpack bundle analyzer plugin
- Checks `MOBIFY_ANALYZE` environment variable and adds it to the webpack plugin list if the value of the variable is `true`
- Opens the analyzer output on build completion

## How to test-drive this PR
- Run `npm install`
- Run `MOBIFY_ANALYZE=true npm run prod:build`
