### PR TITLE
Remove breadcrumbs if running in Astro

### DIFF
--- a/web/app/containers/pdp/partials/pdp-heading.jsx
+++ b/web/app/containers/pdp/partials/pdp-heading.jsx
@@ -7,12 +7,15 @@ import {selectorToJS} from '../../../utils/selector-utils'
 import SkeletonBlock from 'progressive-web-sdk/dist/components/skeleton-block'
 import Breadcrumbs from 'progressive-web-sdk/dist/components/breadcrumbs'
 
+import {isRunningInAstro} from '../../../utils/astro-integration'
+
 const PDPHeading = ({breadcrumbs, title, price}) => (
     <div className="t-pdp-heading u-padding-md u-box-shadow u-position-relative u-z-index-1">
-        <div className="t-pdp__breadcrumbs u-margin-bottom-md">
-            <Breadcrumbs items={breadcrumbs} />
-        </div>
-
+        {!isRunningInAstro &&
+            <div className="t-pdp__breadcrumbs u-margin-bottom-md">
+                <Breadcrumbs items={breadcrumbs} />
+            </div>
+        }
         {title ?
             <h1 className="t-pdp-heading__title u-text-uppercase u-margin-bottom">{title}</h1>
         :

--- a/web/app/containers/pdp/partials/pdp-heading.test.js
+++ b/web/app/containers/pdp/partials/pdp-heading.test.js
@@ -1,7 +1,11 @@
 /* eslint-env jest */
+/* eslint-disable import/namespace */
+
 import React from 'react'
 import ConnectedPDPHeading from './pdp-heading'
 import {mount, shallow} from 'enzyme'
+
+import * as AstroIntegration from '../../../utils/astro-integration'
 
 const PDPHeading = ConnectedPDPHeading.WrappedComponent
 
@@ -29,4 +33,20 @@ test('renders the title and price', () => {
     const priceElement = wrapper.find(`.${ROOT_CLASS}__price`)
     expect(priceElement.length).toBe(1)
     expect(priceElement.text()).toBe('10gp')
+})
+
+test('doesnt render the breadcrumbs if running in Astro', () => {
+    AstroIntegration.isRunningInAstro = true
+
+    const wrapper = shallow(<PDPHeading />)
+    const breadcrumbs = wrapper.find(`.t-pdp__breadcrumbs`)
+    expect(breadcrumbs.length).toBe(0)
+})
+
+test('renders the breadcrumbs if not running in Astro', () => {
+    AstroIntegration.isRunningInAstro = false
+
+    const wrapper = shallow(<PDPHeading />)
+    const breadcrumbs = wrapper.find(`.t-pdp__breadcrumbs`)
+    expect(breadcrumbs.length).toBe(1)
 })

--- a/web/app/containers/plp/partials/plp-header.jsx
+++ b/web/app/containers/plp/partials/plp-header.jsx
@@ -8,12 +8,16 @@ import Link from 'progressive-web-sdk/dist/components/link'
 import SkeletonText from 'progressive-web-sdk/dist/components/skeleton-text'
 import Image from 'progressive-web-sdk/dist/components/image'
 
+import {isRunningInAstro} from '../../../utils/astro-integration'
+
 const PLPHeader = ({title, contentsLoaded}) => (
     <div className="u-flexbox u-align-bottom">
         <div className="u-flex u-padding-top-lg u-padding-bottom-lg u-padding-start-md">
-            <div className="t-plp__breadcrumb">
-                <Link href="/" className="u-text-small">Home</Link>
-            </div>
+            {!isRunningInAstro &&
+                <div className="t-plp__breadcrumb">
+                    <Link href="/" className="u-text-small">Home</Link>
+                </div>
+            }
 
             <div className="u-margin-top-md">
                 {contentsLoaded ?

--- a/web/app/containers/plp/partials/plp-header.test.js
+++ b/web/app/containers/plp/partials/plp-header.test.js
@@ -1,0 +1,34 @@
+/* eslint-env jest */
+/* eslint-disable import/namespace */
+
+import React from 'react'
+import ConnectedPLPHeading from './plp-header'
+import {mount, shallow} from 'enzyme'
+
+import * as AstroIntegration from '../../../utils/astro-integration'
+
+const PLPHeading = ConnectedPLPHeading.WrappedComponent
+
+test('renders without errors', () => {
+    const wrapper = mount(<PLPHeading />)
+
+    expect(wrapper.length).toBe(1)
+})
+
+const ROOT_CLASS = 't-plp'
+
+test('doesnt render the breadcrumbs if running in Astro', () => {
+    AstroIntegration.isRunningInAstro = true
+
+    const wrapper = shallow(<PLPHeading />)
+    const breadcrumbs = wrapper.find(`.${ROOT_CLASS}__breadcrumb`)
+    expect(breadcrumbs.length).toBe(0)
+})
+
+test('renders the breadcrumbs if not running in Astro', () => {
+    AstroIntegration.isRunningInAstro = false
+
+    const wrapper = shallow(<PLPHeading />)
+    const breadcrumbs = wrapper.find(`.${ROOT_CLASS}__breadcrumb`)
+    expect(breadcrumbs.length).toBe(1)
+})

--- a/web/app/containers/plp/partials/plp-header.test.js
+++ b/web/app/containers/plp/partials/plp-header.test.js
@@ -7,10 +7,10 @@ import {mount, shallow} from 'enzyme'
 
 import * as AstroIntegration from '../../../utils/astro-integration'
 
-const PLPHeading = ConnectedPLPHeading.WrappedComponent
+const PLPHeader = ConnectedPLPHeading.WrappedComponent
 
 test('renders without errors', () => {
-    const wrapper = mount(<PLPHeading />)
+    const wrapper = mount(<PLPHeader />)
 
     expect(wrapper.length).toBe(1)
 })
@@ -20,7 +20,7 @@ const ROOT_CLASS = 't-plp'
 test('doesnt render the breadcrumbs if running in Astro', () => {
     AstroIntegration.isRunningInAstro = true
 
-    const wrapper = shallow(<PLPHeading />)
+    const wrapper = shallow(<PLPHeader />)
     const breadcrumbs = wrapper.find(`.${ROOT_CLASS}__breadcrumb`)
     expect(breadcrumbs.length).toBe(0)
 })
@@ -28,7 +28,7 @@ test('doesnt render the breadcrumbs if running in Astro', () => {
 test('renders the breadcrumbs if not running in Astro', () => {
     AstroIntegration.isRunningInAstro = false
 
-    const wrapper = shallow(<PLPHeading />)
+    const wrapper = shallow(<PLPHeader />)
     const breadcrumbs = wrapper.find(`.${ROOT_CLASS}__breadcrumb`)
     expect(breadcrumbs.length).toBe(1)
 })


### PR DESCRIPTION
Removes the breadcrumbs from the PLP and the PDP if running in Astro

 **JIRA**: https://mobify.atlassian.net/browse/HYB-1011

## Changes
- Conditionally show breadcrumbs in PDP
- Conditionally show breadcrumbs in PLP
- Add tests for both

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Go to PLP, breadcrumbs shouldn't be there
- Go to PDP, breadcrumbs shouldn't be there
