### PR TITLE
Checkout persist email

### DIFF
--- a/web/app/containers/checkout-payment/actions.js
+++ b/web/app/containers/checkout-payment/actions.js
@@ -7,7 +7,7 @@ import checkoutPaymentParser from './checkout-payment-parser'
 import {makeJsonEncodedRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
 
 import {getPaymentBillingFormValues} from '../../store/form/selectors'
-import {getCustomerEntityID} from '../../store/checkout/selectors'
+import {getCustomerEntityID, getEmailAddress} from '../../store/checkout/selectors'
 import {getShippingAddress} from '../../store/checkout/shipping/selectors'
 import {getIsLoggedIn} from '../app/selectors'
 
@@ -44,6 +44,7 @@ export const submitPayment = () => {
         const sameAddress = getPaymentBillingFormValues(currentState).billing_same_as_shipping
 
         let address = {}
+        const email = getEmailAddress(currentState)
 
         if (sameAddress) {
             address = getShippingAddress(currentState).toJS()
@@ -78,8 +79,7 @@ export const submitPayment = () => {
                 ...address
             },
             cartId: entityID,
-            // TODO: Obtain email from shipping step
-            email: 'mobifyqa@gmail.com',
+            email,
             paymentMethod: {
                 additional_data: null,
                 method: 'checkmo',

--- a/web/app/containers/checkout-shipping/actions.js
+++ b/web/app/containers/checkout-shipping/actions.js
@@ -94,6 +94,7 @@ export const submitShipping = () => {
             addressLine2,
             country_id,
             city,
+            username,
             region_id,
             region,
             postcode,
@@ -129,7 +130,7 @@ export const submitShipping = () => {
             }
         }
         const persistShippingURL = `https://www.merlinspotions.com/rest/default/V1/${isLoggedIn ? 'carts/mine' : `guest-carts/${entityID}`}/shipping-information`
-        dispatch(receiveCheckoutData({shipping: {address}}))
+        dispatch(receiveCheckoutData({shipping: {address}, emailAddress: username}))
         makeJsonEncodedRequest(persistShippingURL, addressInformation, {method: 'POST'})
             .then((response) => response.json())
             .then((responseJSON) => {

--- a/web/app/store/checkout/selectors.js
+++ b/web/app/store/checkout/selectors.js
@@ -2,3 +2,5 @@ import {getCheckout} from '../../store/selectors'
 import {createGetSelector} from '../../utils/selector-utils'
 
 export const getCustomerEntityID = createGetSelector(getCheckout, 'customerEntityID')
+
+export const getEmailAddress = createGetSelector(getCheckout, 'emailAddress')


### PR DESCRIPTION
This PR adds the users email address to the checkout store

 **JIRA**: n/a
 **Linked PRs**: n/a

## Changes
- Added the email address entered on the shipping page to the checkout store
- Added a selector for the emailAddress 
- Updated checkout payment submission to use email address data from the store

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- add an item to your cart
- proceed to the checkout shipping page
- fill in all form fields (including email address)
- continue to the next step
- click "Place your order" (make sure you have the network tab open so you can examine the request sent)
- view the data sent
- you should see the email address you entered on the shipping page in the place order request payload
