### PR TITLE
Re-work Astro integration to support seamless back transitions

### DIFF
--- a/web/app/app-provider.jsx
+++ b/web/app/app-provider.jsx
@@ -32,7 +32,6 @@ if (isRunningInAstro) {
 const AppProvider = ({store}) => (
     <Provider store={store}>
         <Router history={browserHistory}>
-        <Router>
             <Route path="/" component={App} onChange={OnChange}>
                 <IndexRoute component={Home} routeName="home" />
                 <Route component={Cart} path="checkout/cart/" routeName="cart" />

--- a/web/app/app-provider.jsx
+++ b/web/app/app-provider.jsx
@@ -9,10 +9,31 @@ import {Cart, CheckoutConfirmation, CheckoutPayment, CheckoutShipping, Home, Log
 import CheckoutHeader from './containers/checkout-header/container'
 import CheckoutFooter from './containers/checkout-footer/container'
 
+import {getURL} from './utils/utils'
+import {isRunningInAstro, pwaNavigate} from './utils/astro-integration'
+
+// We define an initial OnChange as a no-op for non-Astro use
+let OnChange = () => {}
+
+if (isRunningInAstro) {
+    // Redefine OnChange to enable Astro integration
+    OnChange = (prevState, nextState, replace, callback) => {
+        if (nextState.location.action === 'POP') {
+            callback()
+            return
+        }
+
+        pwaNavigate({url: getURL(nextState)}).then(() => {
+            callback()
+        })
+    }
+}
+
 const AppProvider = ({store}) => (
     <Provider store={store}>
         <Router history={browserHistory}>
-            <Route path="/" component={App}>
+        <Router>
+            <Route path="/" component={App} onChange={OnChange}>
                 <IndexRoute component={Home} routeName="home" />
                 <Route component={Cart} path="checkout/cart/" routeName="cart" />
                 <Route component={Login} path="customer/account/login/" routeName="signin" />

--- a/web/app/template.jsx
+++ b/web/app/template.jsx
@@ -2,10 +2,9 @@ import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import {onRouteChanged, fetchPage, removeAllNotifications} from './containers/app/actions'
 import {triggerMobifyPageView} from 'progressive-web-sdk/dist/analytics'
-import {isRunningInAstro, pwaNavigate} from './utils/astro-integration'
+import {trigger as astroTrigger} from './utils/astro-integration'
 
 import {getURL, getPath} from './utils/utils'
-import {trigger as astroTrigger} from './utils/astro-integration'
 
 const getDisplayName = (WrappedComponent) => {
     return WrappedComponent.displayName || WrappedComponent.name || 'Component'
@@ -24,10 +23,6 @@ const template = (WrappedComponent) => {
 
             if (route.fetchUrl) {
                 url = route.fetchUrl
-            }
-
-            if (isRunningInAstro && location.action.toLowerCase() !== 'pop') {
-                pwaNavigate(url)
             }
 
             triggerMobifyPageView(route.routeName)

--- a/web/app/template.jsx
+++ b/web/app/template.jsx
@@ -2,7 +2,7 @@ import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import {onRouteChanged, fetchPage, removeAllNotifications} from './containers/app/actions'
 import {triggerMobifyPageView} from 'progressive-web-sdk/dist/analytics'
-import Astro from './vendor/astro-client'
+import {isRunningInAstro, pwaNavigate} from './utils/astro-integration'
 
 import {getURL, getPath} from './utils/utils'
 import {trigger as astroTrigger} from './utils/astro-integration'
@@ -26,8 +26,8 @@ const template = (WrappedComponent) => {
                 url = route.fetchUrl
             }
 
-            if (Astro.isRunningInApp() && location.action.toLowerCase() !== 'pop') {
-                Astro.trigger('pwa-navigate', {url})
+            if (isRunningInAstro && location.action.toLowerCase() !== 'pop') {
+                pwaNavigate(url)
             }
 
             triggerMobifyPageView(route.routeName)

--- a/web/app/template.jsx
+++ b/web/app/template.jsx
@@ -4,13 +4,12 @@ import {onRouteChanged, fetchPage, removeAllNotifications} from './containers/ap
 import {triggerMobifyPageView} from 'progressive-web-sdk/dist/analytics'
 import Astro from './vendor/astro-client'
 
+import {getURL, getPath} from './utils/utils'
+import {trigger as astroTrigger} from './utils/astro-integration'
+
 const getDisplayName = (WrappedComponent) => {
     return WrappedComponent.displayName || WrappedComponent.name || 'Component'
 }
-
-const getPath = ({pathname, search}) => pathname + search
-const getURL = (routerLocation) =>
-      window.location.origin + getPath(routerLocation)
 
 const template = (WrappedComponent) => {
     class Template extends React.Component {
@@ -44,12 +43,26 @@ const template = (WrappedComponent) => {
             this.dispatchRouteChange(this.props)
         }
 
+        componentDidMount() {
+            astroTrigger('pwa-navigated', {
+                url: getURL(this.props.location),
+                source: 'componentDidMount'
+            })
+        }
+
         componentWillReceiveProps(nextProps) {
             if (getPath(this.props.location) !== getPath(nextProps.location)) {
                 console.log('changing', Template.displayName)
                 this.dispatchRouteChange(nextProps)
                 this.props.dispatch(removeAllNotifications())
             }
+        }
+
+        componentDidUpdate() {
+            astroTrigger('pwa-navigated', {
+                url: getURL(this.props.location),
+                source: 'componentDidUpdate'
+            })
         }
 
         render() {

--- a/web/app/utils/astro-integration.js
+++ b/web/app/utils/astro-integration.js
@@ -10,3 +10,10 @@ export const isRunningInAstro = Astro.isRunningInApp()
 export const pwaNavigate = Astro.isRunningInApp()
     ? Astro.jsRpcMethod('pwa-navigate', ['url'])
     : () => {}
+
+/**
+ * Triggers an event into the native Astro app.
+ * This is exactly the same method as documented here:
+ * http://astro.mobify.com/latest/advanced/webview-appjs-communication/
+ */
+export const trigger = Astro.trigger

--- a/web/app/utils/utils.js
+++ b/web/app/utils/utils.js
@@ -40,9 +40,24 @@ export const stripEvent = (fn) => () => fn()
  * Converts a full URL to the preferred format for keying the redux store,
  * i.e. the path and query string
  */
-
 export const urlToPathKey = (url) => {
     const urlObject = new URL(url)
 
     return `${urlObject.pathname}${urlObject.search}`
 }
+
+/**
+ * Returns a path given a `location` object.
+ * @param {object} location - a location object from React Router
+ * @returns {string} - the `path` and `search` concatenated together
+ */
+export const getPath = ({pathname, search}) => pathname + search
+
+/**
+ * Returns a full URL given a `location` object.
+ * @param {object} location - a location object from React Router
+ * @returns {string} - the full URL for the given location
+ */
+export const getURL = (location) =>
+      window.location.origin + getPath(location)
+


### PR DESCRIPTION
Originally we started with using an Astro event to communicate the PWA navigation. I changed it to use an RPC method. At some point the changes to support the RPC on the web side got lost. This fixes the PWA side of in-app navigation.

 **JIRA**: [HYB-962](https://mobify.atlassian.net/browse/HYB-962)
 **Linked PRs**: N/A

## Changes
- Swift from using an Astro event to RPC method (this allows Astro to sit on the navigation while it swaps views before letting it continue)
- Expose `Astro.trigger` through `astro-integration` so that we only ever use `astro-integration` in the PWA.

## How to test-drive this PR
- Run `npm run dev`
- Run the app
- Navigate to some potions
- Navigate back using the header bar
Note: You'll know it's working if you get stacking. No stacking means it's broken!
