### PR TITLE
Fix PDP propType warning

### DIFF
--- a/web/app/containers/pdp/partials/pdp-add-to-cart.jsx
+++ b/web/app/containers/pdp/partials/pdp-add-to-cart.jsx
@@ -56,11 +56,11 @@ const PDPAddToCart = ({quantity, ctaText, setQuantity, onSubmit, disabled}) => {
 
 
 PDPAddToCart.propTypes = {
-    quantity: PropTypes.number.isRequired,
     setQuantity: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
     ctaText: PropTypes.string,
-    disabled: PropTypes.bool
+    disabled: PropTypes.bool,
+    quantity: PropTypes.number
 }
 
 const mapStateToProps = createStructuredSelector({


### PR DESCRIPTION
This PR fixes a Prop Type warning on the PDP. 

 **JIRA**: n/a
 **Linked PRs**: n/a

## Changes
- Remove isRequired from quantity prop on the PDP

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Navigate to any PDP
- No prop type warning should show in the console
- Add 2 of the item to your cart
- Navigate to the cart and click "Edit"
- Confirm the correct qty (ie. 2) is shown on the edit version of the PDP
