### PR TITLE
Fix for cart state checking when Magento has full page cache enabled

### DIFF
--- a/web/app/store/cart/actions.js
+++ b/web/app/store/cart/actions.js
@@ -11,7 +11,7 @@ import {makeFormEncodedRequest, makeRequest} from 'progressive-web-sdk/dist/util
 import {addNotification, removeNotification} from '../../containers/app/actions'
 import {getFormKey} from '../../containers/app/selectors'
 
-const LOAD_CART_SECTION_URL = '/customer/section/load/?sections=cart'
+const LOAD_CART_SECTION_URL = '/customer/section/load/?sections=cart%2Cmessages&update_section_id=true&_=<timestamp>'
 const REMOVE_CART_ITEM_URL = '/checkout/sidebar/removeItem/'
 const UPDATE_ITEM_URL = '/checkout/sidebar/updateItemQty/'
 const baseHeaders = {
@@ -28,7 +28,7 @@ export const getCart = () => (dispatch) => {
         headers: baseHeaders
     }
     dispatch(removeNotification('cartUpdateError'))
-    return utils.makeRequest(LOAD_CART_SECTION_URL, opts)
+    return utils.makeRequest(`${LOAD_CART_SECTION_URL}${new Date().getTime()}`, opts)
         .then((response) => response.text())
         .then((responseText) => dispatch(receiveCartContents(parse(responseText))))
 }


### PR DESCRIPTION
Update the cart checking functionality with changes required when the Magento 'full page cache' is enabled.

 **JIRA**: https://mobify.atlassian.net/browse/PLATT-95
 **Linked PRs**: https://github.com/mobify/merlins-potions-magento/pull/14

## Changes
- Added required parameters to the 'fetch cart contents' request

## How to test-drive this PR
- Run against the Merlins backend build from the linked PR, or the live one (this change works for the backend with 'full page cache' both enabled or disabled)
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Add something to the cart - observe everything works now when interacting with a backend with 'full page cache' enabled. 
