### PR TITLE
Somehow the instructions for installing a cert to fix SSL errors got …

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -7,6 +7,26 @@ npm install
 npm run dev
 ```
 
+## Prevent SSL Errors in Preview (on a Mac)
+
+The development server uses a self-signed SSL certificate which is
+valid, but treated as suspect by browsers. This means that we must
+create and reconfirm security exceptions for it, and avoid localhost
+for certain use cases (such as service workers).
+
+To add the certificate to the Mac system trust store and make the
+browsers accept it, do the following:
+
+1. In the root of the project directory, run `open node_modules/webpack-dev-server/ssl/server.crt`.
+2. Open `Keychain Access` -> go to `Certificates` -> select `localhost`
+3. Right click on the entry and select `Get Info`
+4. Expand the `Trust` section
+5. Set `Secure Socket Layer (SSL)` to `Always Trust`
+6. Close the info window. You will need to enter your password.
+
+This process will allow all projects hosted with `webpack-dev-server`
+version 1.15.0 and up to be trusted by your browsers.
+
 ## Adding a page (container)
 
 ```


### PR DESCRIPTION
…removed. This restores it.

(brief description / PR title)

 **JIRA**: (link to JIRA ticket)
 **Linked PRs**: (links to corresponding PRs, optional)

## Changes
- (change1)

## How to test-drive this PR
- (necessary config changes)
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- (how to access the new / changed functionality -- fixtures, URLs)
