### PR TITLE
Added to cart modal “go to checkout” goes to shipping page 

### DIFF
--- a/web/app/containers/product-details/actions.js
+++ b/web/app/containers/product-details/actions.js
@@ -35,7 +35,7 @@ export const goToCheckout = () => (dispatch) => {
         // otherwise, navigating is taken care of by the button press
         Astro.trigger('open:cart-modal')
     } else {
-        browserHistory.push('/checkout/')
+        browserHistory.push('/checkout/cart/')
     }
 }
 


### PR DESCRIPTION
Added to cart modal “go to checkout” goes to shipping page when it should link to cart

## Changes
- Added to cart modal “go to checkout” goes to cart

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Add an item to cart and click on "Go to checkout" 
