### PR TITLE
fix letter spacing in cart and checkout

### DIFF
--- a/web/app/containers/cart/partials/cart-product-list.jsx
+++ b/web/app/containers/cart/partials/cart-product-list.jsx
@@ -105,7 +105,7 @@ class CartProductItem extends React.Component {
 
                 <div className="u-flexbox">
                     <Button
-                        className="u-text-small u-color-brand u-flex-none"
+                        className="u-text-small u-color-brand u-flex-none u-text-letter-spacing-normal"
                         innerClassName="c--no-min-width u-padding-start-0 u-padding-bottom-0"
                         href={configure_url}
                         >
@@ -113,7 +113,7 @@ class CartProductItem extends React.Component {
                     </Button>
 
                     <Button
-                        className="u-text-small u-color-brand u-padding-start-0 u-padding-end-0"
+                        className="u-text-small u-color-brand u-padding-start-0 u-padding-end-0 u-text-letter-spacing-normal"
                         innerClassName="u-padding-bottom-0"
                         onClick={this.saveForLater}
                         >
@@ -121,7 +121,7 @@ class CartProductItem extends React.Component {
                     </Button>
 
                     <Button
-                        className="u-text-small u-color-brand qa-cart__remove-item"
+                        className="u-text-small u-color-brand u-text-letter-spacing-normal qa-cart__remove-item"
                         innerClassName="u-padding-end-0 u-padding-bottom-0"
                         onClick={this.removeItem}
                         >
@@ -161,7 +161,7 @@ const CartProductList = ({items, summaryCount, onSaveLater, onUpdateItemQuantity
                     <h1 className="u-flex">
                         Cart {summaryCount > 0 && <span>({summaryCount} Items)</span>}
                     </h1>
-                    <Button className="u-flex-none u-color-brand" onClick={onOpenSignIn}>
+                    <Button className="u-flex-none u-color-brand u-text-letter-spacing-normal" onClick={onOpenSignIn}>
                         <Icon name="user" />
                         Sign in
                     </Button>

--- a/web/app/containers/cart/partials/cart-summary.jsx
+++ b/web/app/containers/cart/partials/cart-summary.jsx
@@ -13,7 +13,7 @@ import {Ledger, LedgerRow} from 'progressive-web-sdk/dist/components/ledger'
 
 const CartSummary = ({summaryCount, subtotalExclTax, subtotalInclTax, shippingRate, onCalculateClick}) => {
     const calculateButton = (
-        <Button innerClassName="u-padding-end-0 u-color-brand" onClick={onCalculateClick}>
+        <Button innerClassName="u-padding-end-0 u-color-brand u-text-letter-spacing-normal" onClick={onCalculateClick}>
             Calculate <Icon name="chevron-right" />
         </Button>
     )

--- a/web/app/containers/checkout-header/container.js
+++ b/web/app/containers/checkout-header/container.js
@@ -27,6 +27,7 @@ const CheckoutHeader = function({isLoggedIn, isRunningInAstro}) {
                 {!isLoggedIn &&
                     <div className="u-flex u-text-align-end">
                         <Button
+                            className= "u-text-letter-spacing-normal"
                             href="/customer/account/login/"
                             innerClassName="u-color-neutral-10"
                             >

--- a/web/app/containers/checkout-header/container.js
+++ b/web/app/containers/checkout-header/container.js
@@ -27,7 +27,7 @@ const CheckoutHeader = function({isLoggedIn, isRunningInAstro}) {
                 {!isLoggedIn &&
                     <div className="u-flex u-text-align-end">
                         <Button
-                            className= "u-text-letter-spacing-normal"
+                            className="u-text-letter-spacing-normal"
                             href="/customer/account/login/"
                             innerClassName="u-color-neutral-10"
                             >


### PR DESCRIPTION
Letter spacing of link text is too big (affecting multiple areas including the checkout header at 320px)

## Changes
- set letter-spacing to initial for links in cart and checkout

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Add an item to cart and go to cart
- Proceed to checkout 