### PR TITLE
Fail build when web pack failed

### DIFF
--- a/web/scripts/build.sh
+++ b/web/scripts/build.sh
@@ -3,7 +3,7 @@
 rimraf build/
 sdk-get-routes
 sdk-create-hash-manifest
-webpack --config webpack/production.js -p --display-error-details
+webpack --config webpack/production.js -p --display-error-details --bail
 
 # Copy native onboarding
 rimraf ../native/app/build/app-www/onboarding/*

--- a/web/scripts/build.sh
+++ b/web/scripts/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 rimraf build/
 sdk-get-routes


### PR DESCRIPTION
Fail project build if it detects error when Webpack is building. We want to ensure no bundle is uploaded to cloud if webpack or build script failed

## Research
Webpack doesn't exit with error code 1 without the `--bail` flag
Bash scripts needs `set -e` to propagate error up the chain

## How to test-drive this PR
Make sure your are in a bad environment that the build should fail
```
rm -r /node_modules/node-sass/vendor/darwin-x64-51/
nvm use v7
```
Run either commands:
```
npm run push --m "Test - should not push"
// or
npm run prod:build
```
**Expected:** Neither command should succeed
