### PR TITLE
PLATT-43: nearby widget fix

### DIFF
--- a/web/app/config/merlins-potions-nearby-config.json
+++ b/web/app/config/merlins-potions-nearby-config.json
@@ -5,7 +5,7 @@
             "selector": "#donde-closest-locations-widget-1",
             "nthNearest": 1,
             "maxDistance": "100",
-            "showSpinner": true,
+            "showSpinner": false,
             "template": "<% if(id){ %> <div class=\"pw-list-tile c-list-tile u-border-light-bottom u-text-font-family pw--is-anchor c--is-anchor\"><a href=\"http://locations.merlinspotions.com<%=llpURL%>\" class=\"pw-link c-link pw-list-tile__primary c-list-tile__primary\"><div class=\"pw-list-tile__action c-list-tile__action\"><svg aria-hidden=\"true\" class=\"pw-icon c-icon\" title=\"Store Icon\" aria-labelledby=\"icon-888\"><title id=\"icon-888\"></title><use role=\"img\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xlink:href=\"#pw-store\"></use></svg></div><div class=\"pw-list-tile__content c-list-tile__content u-padding-0 u-justify-between u-row\"> <div><%=city%></div> <div class=\"u-text-bold\"><%=distanceKM%>km</div> </div><div class=\"pw-list-tile__action c-list-tile__action\"><button class=\"pw-button c-button c--blank pw--icon-only c--icon-only\" type=\"button\"><div class=\"pw-button__inner c-button__inner\"><svg aria-hidden=\"true\" class=\"pw-icon c-icon pw-button__icon c-button__icon\" title=\"Chevron Right Icon\" aria-labelledby=\"icon-999\"><title id=\"icon-999\"></title><use role=\"img\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xlink:href=\"#pw-chevron-right\"></use></svg></div></button></div></a></div> <% } else { %> <div class=\"u-padding-md u-text-align-center\">Sorry, No locations near you.</div> <% } %>"
         },
         {

--- a/web/app/containers/home/_home.scss
+++ b/web/app/containers/home/_home.scss
@@ -69,3 +69,18 @@
         line-height: 25px;
     }
 }
+
+
+// Nearest Stores
+// ---
+
+.t-home__nearest-stores {
+    a {
+        color: $brand-color;
+
+        &:active,
+        &:focus {
+            color: $tertiary-brand-color;
+        }
+    }
+}

--- a/web/app/containers/home/container.js
+++ b/web/app/containers/home/container.js
@@ -3,18 +3,12 @@ import React from 'react'
 // Partials
 import HomeCarousel from './partials/home-carousel'
 import HomeCategories from './partials/home-categories'
-import HomeNearestStores from './partials/home-nearest-stores'
-
-import {isRunningInAstro} from '../../utils/astro-integration'
 
 const Home = () => {
     return (
         <div className="t-home__container">
             <HomeCarousel />
             <HomeCategories />
-            {!isRunningInAstro &&
-                <HomeNearestStores title="Nearest Stores" viewAllStoresText="View All Stores" className="u-padding-start u-padding-end u-padding-bottom-md" />
-            }
         </div>
     )
 }

--- a/web/app/containers/home/partials/home-nearest-stores.jsx
+++ b/web/app/containers/home/partials/home-nearest-stores.jsx
@@ -1,6 +1,9 @@
 /* eslint-disable react/self-closing-comp */
 import React, {PropTypes} from 'react'
 import Button from 'progressive-web-sdk/dist/components/button'
+import ListTile from 'progressive-web-sdk/dist/components/list-tile'
+import SkeletonText from 'progressive-web-sdk/dist/components/skeleton-text'
+import SkeletonBlock from 'progressive-web-sdk/dist/components/skeleton-block'
 
 // Merlins Potions Nearby Widget Config
 import merlinsPotionsNearbyConfig from '../../../config/merlins-potions-nearby-config.json'
@@ -51,12 +54,23 @@ class HomeNearestStores extends React.Component {
 
                     <div className="u-margin-bottom-md">
 
-                        {closestLocations.map((id, idx) => {
-                            let selectorString = id.selector
+                        {closestLocations.map((selector, idx) => { // id seems like a misleading var name
+                            let selectorString = selector.selector
                             selectorString = selectorString.slice(1, selectorString.length)
 
                             return (
-                                <div id={selectorString} key={idx}></div>
+                                <div id={selectorString} key={idx}>
+                                    <ListTile
+                                        className="u-border-light-bottom"
+                                        startAction={<SkeletonBlock height="20px" width="20px" />}
+                                        endAction={<SkeletonBlock height="20px" width="20px" />}
+                                    >
+                                        <SkeletonText
+                                            style={{height: '25px', lineHeight: '20px'}}
+                                            width="100px"
+                                        />
+                                    </ListTile>
+                                </div>
                             )
                         })}
                     </div>

--- a/web/app/containers/home/partials/home-nearest-stores.jsx
+++ b/web/app/containers/home/partials/home-nearest-stores.jsx
@@ -5,8 +5,6 @@ import Button from 'progressive-web-sdk/dist/components/button'
 // Merlins Potions Nearby Widget Config
 import merlinsPotionsNearbyConfig from '../../../config/merlins-potions-nearby-config.json'
 
-const componentClass = 'c-nearest-stores'
-
 /**
  * Merlins Donde Nearby Widget
  */
@@ -47,7 +45,7 @@ class HomeNearestStores extends React.Component {
         const closestLocations = merlinsPotionsNearbyConfig.configs
 
         return (
-            <div className={componentClass}>
+            <div className="t-home__nearest-stores">
                 <div className="u-card u-padding-md u-padding-top-lg u-padding-bottom-lg">
                     <h2 className="u-padding-bottom-md u-border-light-bottom u-text-uppercase">{title}</h2>
 


### PR DESCRIPTION
Remove Nearest Store widget on home page. Will need to add more work to Nearest Store widget when we get final answer from Product Manager and designer. It will not be on home page, it will be on different page. 

 **JIRA**: https://mobify.atlassian.net/browse/PLATT-43
 **Linked PRs**: n/a

## Changes
- remove Nearest Store Widget on home page
- add placeholder to nearest store partial 

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Make sure that there is no Nearest Store Widget on home page. 
