### PR TITLE
Add email placeholder

### DIFF
--- a/web/app/containers/checkout-shipping/partials/shipping-email.jsx
+++ b/web/app/containers/checkout-shipping/partials/shipping-email.jsx
@@ -28,7 +28,7 @@ const ShippingEmail = ({submitSignIn, customerEmailRecognized, checkCustomerEmai
 
                 <FieldRow>
                     <ReduxForm.Field component={Field} className="pw--overlayed-hint" name="username" label="Email order confirmation to">
-                        <input type="email" noValidate onBlur={checkCustomerEmail} />
+                        <input type="email" noValidate onBlur={checkCustomerEmail} placeholder="Email Address" />
                     </ReduxForm.Field>
                 </FieldRow>
 


### PR DESCRIPTION
No default text in email field, should read “Email Address”

## Changes
- add placeholder to email address

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Add an item to cart and go to cart
- Proceed to checkout to get to shipping step
