### PR TITLE
Astro: Merlin's Android back button handling

### DIFF
--- a/native/app/controllers/tabBarController.js
+++ b/native/app/controllers/tabBarController.js
@@ -1,5 +1,6 @@
 import AnchoredLayoutPlugin from 'progressive-app-sdk/plugins/anchoredLayoutPlugin'
 import TabBarPlugin from 'progressive-app-sdk/plugins/tabBarPlugin'
+import Application from 'progressive-app-sdk/application'
 
 import {tabBarConfig} from '../config/tabBarConfig'
 import baseConfig from '../config/baseConfig'
@@ -99,6 +100,8 @@ TabBarController.prototype.backActiveItem = async function() {
     if (await this.canGoBack()) {
         const activeTab = this.getActiveController()
         activeTab.back()
+    } else {
+        Application.closeApp()
     }
 }
 

--- a/native/app/controllers/tabController.js
+++ b/native/app/controllers/tabController.js
@@ -2,7 +2,6 @@ import Promise from 'bluebird'
 
 import AnchoredLayoutPlugin from 'progressive-app-sdk/plugins/anchoredLayoutPlugin'
 import NavigationPlugin from 'progressive-app-sdk/plugins/navigationPlugin'
-import Application from 'progressive-app-sdk/application'
 
 import AppEvents from '../global/app-events'
 import TabHeaderController from './tabHeaderController'
@@ -100,15 +99,8 @@ TabController.prototype.canGoBack = async function() {
     return await this.navigationView.canGoBack()
 }
 
-TabController.prototype.back = async function() {
-    const webView = await this.navigationView.getTopPlugin()
-    const canGoBack = await webView.canGoBack()
-    if (canGoBack) {
-        webView.back()
-    } else {
-        Application.closeApp()
-    }
-
+TabController.prototype.back = function() {
+    this.navigationView.back()
 }
 
 export {Events}


### PR DESCRIPTION
Fixes the previous broken back button on Android

## Changes
- TabbarController handles the closes

## How to test-drive this PR
- on Android go on shop -> product listing page
- press the hardware back button, should go back navigation and once it is at root, it should close the app. 
