### PR TITLE
add uppercase utility class to elements with h4 formatting

### DIFF
--- a/web/app/containers/cart/partials/cart-summary.jsx
+++ b/web/app/containers/cart/partials/cart-summary.jsx
@@ -20,12 +20,10 @@ const CartSummary = ({summaryCount, subtotalExclTax, subtotalInclTax, shippingRa
 
     return (
         <div className="t-cart__summary">
-            <div className="t-cart__summary-title">
-                <div className="u-flexbox u-align-center">
-                    <h2 className="u-flex">
-                        Order Summary
-                    </h2>
-                </div>
+            <div className="t-cart__summary-title u-padding-top-lg u-padding-bottom-md">
+                <h2 className="u-h4 u-text-uppercase">
+                    Order Summary
+                </h2>
             </div>
 
             <div className="u-bg-color-neutral-00 u-border-light-top u-border-light-bottom">

--- a/web/app/containers/checkout-payment/partials/billing-address-form.jsx
+++ b/web/app/containers/checkout-payment/partials/billing-address-form.jsx
@@ -70,7 +70,7 @@ class BillingAddressForm extends React.Component {
         return (
             <div>
                 <div className="t-checkout-payment__title u-padding-top-lg u-padding-bottom-md">
-                    <h2 className="u-h4">Billing Address</h2>
+                    <h2 className="u-h4 u-text-uppercase">Billing Address</h2>
                 </div>
 
                 <div className="u-border-light-top u-border-light-bottom u-bg-color-neutral-00 t-checkout-payment__card">

--- a/web/app/containers/checkout-payment/partials/credit-card-form.jsx
+++ b/web/app/containers/checkout-payment/partials/credit-card-form.jsx
@@ -102,7 +102,7 @@ class CreditCardForm extends React.Component {
         return (
             <div>
                 <div className="t-checkout-payment__title u-padding-top-lg u-padding-bottom-md">
-                    <h2 className="u-h4">Pay With Card</h2>
+                    <h2 className="u-h4 u-text-uppercase">Pay With Card</h2>
                 </div>
 
                 {hasExistingCreditCard ?

--- a/web/app/containers/checkout-payment/partials/order-summary.jsx
+++ b/web/app/containers/checkout-payment/partials/order-summary.jsx
@@ -70,7 +70,7 @@ class OrderSummary extends React.Component {
         return (
             <div className="t-checkout-payment__order-summary">
                 <div className="t-checkout-payment__title u-padding-top-lg u-padding-bottom-md">
-                    <h2 className="u-h4">Order Summary</h2>
+                    <h2 className="u-h4 u-text-uppercase">Order Summary</h2>
                 </div>
 
                 <div className="u-border-light-top u-border-light-bottom u-bg-color-neutral-00 t-checkout-payment__card">

--- a/web/tests/system/page-objects/product-details.js
+++ b/web/tests/system/page-objects/product-details.js
@@ -1,7 +1,7 @@
 const selectors = {
     productDetailsTemplateIdentifier: '.t-product-details',
     addItem: '.t-product-details__add-to-cart:not([disabled])',
-    itemAdded: '.t-pproduct-list__item-added-modal .u-h4',
+    itemAdded: '.t-pproduct-list__item-added-modal .u-h4 .u-text-uppercase',
     goToCart: '.t-product-list__item-added-modal a[href*="cart"]'
 }
 


### PR DESCRIPTION
H4 formatting in cart and checkout should be all CAPS

## Changes
- add uppercase utility class to elements with h4 formatting

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- add item to cart and go through the checkout
- check "h4" headings are in CAPS
