### PR TITLE
WEB-1233: Prevent duplicate page request by using initial captured doc

### DIFF
--- a/web/app/containers/app/actions.js
+++ b/web/app/containers/app/actions.js
@@ -117,7 +117,8 @@ const requestCapturedDoc = () => {
  */
 export const fetchPage = (url, pageComponent, routeName, fetchUrl) => {
     return (dispatch, getState) => {
-        const request = isInitialEntryToSite ? requestCapturedDoc() : makeRequest(fetchUrl || url)
+        const isNotTestingEnvironment = !!window.Progressive
+        const request = isInitialEntryToSite && isNotTestingEnvironment ? requestCapturedDoc() : makeRequest(fetchUrl || url)
         isInitialEntryToSite = false
 
         return request

--- a/web/app/containers/app/actions.js
+++ b/web/app/containers/app/actions.js
@@ -33,6 +33,8 @@ import {OFFLINE_ASSET_URL} from './constants'
 import {closeModal} from '../../store/modals/actions'
 import {OFFLINE_MODAL} from '../offline/constants'
 
+let isInitialEntryToSite = true
+
 export const addNotification = utils.createAction('Add Notification')
 export const removeNotification = utils.createAction('Remove Notification')
 export const removeAllNotifications = utils.createAction('Remove All Notifications')
@@ -99,13 +101,26 @@ export const checkIfOffline = () => {
     }
 }
 
+const requestCapturedDoc = () => {
+    const body = new Blob([window.Progressive.initialCapturedDocHTML], {type: 'text/html'})
+    const capturedDocResponse = new Response(body, {
+        status: 200,
+        statusText: 'OK'
+    })
+
+    return Promise.resolve(capturedDocResponse)
+}
+
 /**
  * Fetch the content for a 'global' page render. This should be driven
  * by react-router, ideally.
  */
 export const fetchPage = (url, pageComponent, routeName, fetchUrl) => {
     return (dispatch, getState) => {
-        return makeRequest(fetchUrl || url)
+        const request = isInitialEntryToSite ? requestCapturedDoc() : makeRequest(fetchUrl || url)
+        isInitialEntryToSite = false
+
+        return request
             .then(jqueryResponse)
             .then((res) => {
                 const [$, $response] = res


### PR DESCRIPTION
 **JIRA**: https://mobify.atlassian.net/browse/WEB-1233
 **Linked PRs**:
https://github.com/mobify/crabtree-evelyn-progressive/pull/572
https://github.com/mobify/lancome-progressive/pull/846

**Before**
![screen shot 2017-03-06 at 2 41 01 pm](https://cloud.githubusercontent.com/assets/4543395/23633533/f7585bd0-027a-11e7-8f55-86ad5f52ede6.png)


**After** Saves about ~0.5s
![screen shot 2017-03-06 at 2 40 17 pm](https://cloud.githubusercontent.com/assets/4543395/23633520/e8753b56-027a-11e7-8d5b-173cc53b9298.png)


## Changes
- A flag to keep track of initial entry to the site
- Retrieved the captured document's html if initial entry

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Confirm in Chrome's network tab that we are not requesting homepage twice.
- Confirm you can still navigate to other parts of the site successfully