### PR TITLE
WEB-1242: Remove SVG from bundle

### DIFF
--- a/web/app/containers/app/actions.js
+++ b/web/app/containers/app/actions.js
@@ -1,7 +1,8 @@
 import {jqueryResponse} from 'progressive-web-sdk/dist/jquery-response'
 import {makeRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
-import * as utils from '../../utils/utils'
-import * as selectors from './selectors'
+import {getAssetUrl} from 'progressive-web-sdk/dist/asset-utils'
+import {createAction} from '../../utils/utils'
+import {getCurrentUrl} from './selectors'
 
 import appParser from './app-parser'
 
@@ -33,16 +34,18 @@ import {OFFLINE_ASSET_URL} from './constants'
 import {closeModal} from '../../store/modals/actions'
 import {OFFLINE_MODAL} from '../offline/constants'
 
-export const addNotification = utils.createAction('Add Notification')
-export const removeNotification = utils.createAction('Remove Notification')
-export const removeAllNotifications = utils.createAction('Remove All Notifications')
+export const addNotification = createAction('Add Notification')
+export const removeNotification = createAction('Remove Notification')
+export const removeAllNotifications = createAction('Remove All Notifications')
+
+export const updateSvgSprite = createAction('Updated SVG sprite', 'sprite')
 
 /**
  * Action dispatched when the route changes
  * @param {string} pageComponent - the component of the entered route
  * @param {string} currentURL - what's currently shown in the address bar
  */
-export const onRouteChanged = utils.createAction('On route changed', 'currentURL', 'pageComponent')
+export const onRouteChanged = createAction('On route changed', 'currentURL', 'pageComponent')
 
 /**
  * Action dispatched when content for a global page render is ready.
@@ -53,7 +56,7 @@ export const onRouteChanged = utils.createAction('On route changed', 'currentURL
  * @param {string} currentURL - what's currently shown in the address bar
  * @param {string} routeName - the name of the route we received the page for
  */
-export const onPageReceived = utils.createAction('On page received',
+export const onPageReceived = createAction('On page received',
     '$',
     '$response',
     'url',
@@ -61,13 +64,13 @@ export const onPageReceived = utils.createAction('On page received',
     'routeName'
 )
 
-export const receiveData = utils.createAction('Receive App Data')
+export const receiveData = createAction('Receive App Data')
 export const process = ({payload: {$response}}) => {
     return receiveData(appParser($response))
 }
 
-export const setPageFetchError = utils.createAction('Set page fetch error', 'fetchError')
-export const clearPageFetchError = utils.createAction('Clear page fetch error')
+export const setPageFetchError = createAction('Set page fetch error', 'fetchError')
+export const clearPageFetchError = createAction('Clear page fetch error')
 
 /**
  * Make a separate request that is intercepted by the worker. The worker will
@@ -110,7 +113,7 @@ export const fetchPage = (url, pageComponent, routeName, fetchUrl) => {
             .then((res) => {
                 const [$, $response] = res
 
-                const currentURL = selectors.getCurrentUrl(getState())
+                const currentURL = getCurrentUrl(getState())
                 const receivedAction = onPageReceived($, $response, url, currentURL, routeName)
 
                 // Let app-level reducers know about receiving the page
@@ -156,5 +159,20 @@ export const fetchPage = (url, pageComponent, routeName, fetchUrl) => {
                     dispatch(setPageFetchError(error.message))
                 }
             })
+    }
+}
+
+/**
+ * Until the day that the `use` element's cross-domain issues are fixed, we are
+ * forced to fetch the SVG Sprite's XML as a string and manually inject it into
+ * the DOM. See here for details on the issue with `use`:
+ * @URL: https://bugs.chromium.org/p/chromium/issues/detail?id=470601
+ */
+export const fetchSvgSprite = () => {
+    return (dispatch) => {
+        const spriteUrl = getAssetUrl('static/svg/sprite-dist/sprite.svg')
+        return makeRequest(spriteUrl)
+            .then((response) => response.text())
+            .then((text) => dispatch(updateSvgSprite(text)))
     }
 }

--- a/web/app/containers/app/container.js
+++ b/web/app/containers/app/container.js
@@ -16,9 +16,6 @@ import * as selectors from './selectors'
 
 import NotificationManager from '../../components/notification-manager'
 
-// @TODO: Replace this with an action that fetches the SVG file via Ajax
-import sprite from '../../static/svg/sprite-dist/sprite.svg'
-
 // Offline support
 import {Offline} from '../templates'
 import OfflineBanner from '../offline/partials/offline-banner'
@@ -35,6 +32,7 @@ const hidePreloaderWhenCSSIsLoaded = () => {
 class App extends React.Component {
     componentDidMount() {
         hidePreloaderWhenCSSIsLoaded()
+        this.props.fetchSvgSprite()
     }
 
     render() {
@@ -45,7 +43,8 @@ class App extends React.Component {
             fetchError,
             hasFetchedCurrentPath,
             notifications,
-            removeNotification
+            removeNotification,
+            sprite
         } = this.props
 
         const routeProps = children.props.route
@@ -126,21 +125,28 @@ App.propTypes = {
      * The react-router history object
      */
     fetchError: PropTypes.string,
+    fetchSvgSprite: PropTypes.func,
     hasFetchedCurrentPath: PropTypes.bool,
     history: PropTypes.object,
     notifications: PropTypes.array,
-    removeNotification: PropTypes.func
+    removeNotification: PropTypes.func,
+    /**
+     * The SVG icon sprite needed in order for all Icons to work
+     */
+    sprite: PropTypes.string,
 }
 
 const mapStateToProps = createStructuredSelector({
     notifications: selectorToJS(selectors.getNotifications),
     fetchError: selectors.getFetchError,
-    hasFetchedCurrentPath: selectors.hasFetchedCurrentPath
+    hasFetchedCurrentPath: selectors.hasFetchedCurrentPath,
+    sprite: selectors.getSvgSprite
 })
 
 const mapDispatchToProps = {
     removeNotification: appActions.removeNotification,
-    fetchPage: appActions.fetchPage
+    fetchPage: appActions.fetchPage,
+    fetchSvgSprite: () => appActions.fetchSvgSprite()
 }
 
 export default connect(

--- a/web/app/containers/app/reducer.js
+++ b/web/app/containers/app/reducer.js
@@ -10,7 +10,8 @@ const initialState = fromJS({
     [CURRENT_URL]: window.location.href,
     notifications: [],
     fetchError: null,
-    [FETCHED_PATHS]: {}
+    [FETCHED_PATHS]: {},
+    sprite: ''
 })
 
 export default handleActions({
@@ -39,5 +40,8 @@ export default handleActions({
     [appActions.setPageFetchError]: mergePayload,
     [appActions.clearPageFetchError]: (state) => {
         return state.set('fetchError', null)
+    },
+    [appActions.updateSvgSprite]: (state, {payload}) => {
+        return state.set('sprite', payload.sprite)
     }
 }, initialState)

--- a/web/app/containers/app/selectors.js
+++ b/web/app/containers/app/selectors.js
@@ -18,3 +18,4 @@ export const hasFetchedCurrentPath = createHasSelector(getFetchedPaths, getCurre
 
 export const getIsLoggedIn = createGetSelector(getApp, 'isLoggedIn')
 export const getFormKey = createGetSelector(getApp, 'formKey')
+export const getSvgSprite = createGetSelector(getApp, 'sprite')


### PR DESCRIPTION
 **JIRA**: https://mobify.atlassian.net/browse/WEB-1241
 **Linked PRs**:
https://github.com/mobify/crabtree-evelyn-progressive/pull/575
https://github.com/mobify/lancome-progressive/pull/843

**Before**
![screen shot 2017-03-06 at 3 54 34 pm](https://cloud.githubusercontent.com/assets/4543395/23635531/3cf2f8da-0285-11e7-9856-c8320f8e7553.png)

**After**
![screen shot 2017-03-06 at 3 54 27 pm](https://cloud.githubusercontent.com/assets/4543395/23635532/3cf67d98-0285-11e7-97da-2ebb4e81c076.png)

## Changes
- Remove importing of SVG file into the bundle
- Add actions/reducers/etc. to pull in the SVG file via Ajax

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Verify icons appears fine

- Run `MOBIFY_ANALYZE=true npm run prod:build`
- View the Webpack Analyzer report and verify that the SVG sprite is no longer in the App files 
