### PR TITLE
WEB-1228: Hot fix singular list children regression

### DIFF
--- a/web/app/containers/product-list/partials/product-list-contents.jsx
+++ b/web/app/containers/product-list/partials/product-list-contents.jsx
@@ -22,20 +22,18 @@ ResultList.propTypes = {
 }
 
 const NoResultsList = ({bodyText}) => (
-    <List className="c--borderless">
-        <div className="u-flexbox u-direction-column u-align-center">
-            <Image
-                className="u-flex-none"
-                alt="Crystal Ball"
-                width="122px"
-                height="110px"
-                src={getAssetUrl('static/img/global/no-results.png')} />
+    <div className="u-flexbox u-direction-column u-align-center">
+        <Image
+            className="u-flex-none"
+            alt="Crystal Ball"
+            width="122px"
+            height="110px"
+            src={getAssetUrl('static/img/global/no-results.png')} />
 
-            <div className="t-product-list__no-results-text u-text-align-center">
-                {bodyText}
-            </div>
+        <div className="t-product-list__no-results-text u-text-align-center">
+            {bodyText}
         </div>
-    </List>
+    </div>
 )
 
 NoResultsList.propTypes = {


### PR DESCRIPTION
 **JIRA**: https://mobify.atlassian.net/browse/WEB-1228
 **Linked PRs**:
- SDK regression introduced by: https://github.com/mobify/progressive-web-sdk/pull/511
- SDK fix (not released yet): https://github.com/mobify/progressive-web-sdk/pull/529

## Changes
- Unwrap the 'no results' content from `List` component. Verified that the `List` component didn't have any styling impact on the 'no results' contents

## Notes
- I've checked the site, it appears this regression only happens when we have 1 children inside the `<List />` component.  Another note.. if we have a map with only 1 item, it'll still work with the `<List />` component.

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Go to https://www.merlinspotions.com/ingredients.html and you should see no results contents
