### PR TITLE
Fix Add to Cart when Magento Full Page Cache is enabled

### DIFF
--- a/web/app/containers/product-details/actions.js
+++ b/web/app/containers/product-details/actions.js
@@ -24,6 +24,7 @@ const generateRandomString = (chars, length) => {
     return result
 }
 
+// Set the cookie and returns the value
 const generateFormKeyCookie = () => {
     // From Magento page-cache.js
     const allowedCharacters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'

--- a/web/app/containers/product-details/actions.js
+++ b/web/app/containers/product-details/actions.js
@@ -1,4 +1,5 @@
 import {createAction, getCookieValue, urlToPathKey} from '../../utils/utils'
+import {generateFormKeyCookie} from '../../utils/magento-utils'
 import {makeFormEncodedRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
 import {browserHistory} from 'react-router'
 
@@ -11,30 +12,6 @@ import productDetailsParser from './parsers/product-details'
 
 import {isRunningInAstro} from '../../utils/astro-integration'
 import Astro from '../../vendor/astro-client'
-
-// From Magento page-cache.js
-const generateRandomString = (chars, length) => {
-    let result = ''
-    length = length > 0 ? length : 1
-
-    while (length--) {
-        result += chars[Math.round(Math.random() * (chars.length - 1))]
-    }
-
-    return result
-}
-
-// Set the cookie and returns the value
-const generateFormKeyCookie = () => {
-    // From Magento page-cache.js
-    const allowedCharacters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
-    const length = 16
-    const generatedKey = generateRandomString(allowedCharacters, length)
-    const lifetime = 3600
-    const expires = new Date((new Date().getTime()) + lifetime * 1000)
-    document.cookie = `form_key=${encodeURIComponent(generatedKey)}; expires=${expires.toGMTString()}; domain=.${window.location.hostname}`
-    return generatedKey
-}
 
 export const receiveNewItemQuantity = createAction('Set item quantity')
 export const setItemQuantity = (quantity) => (dispatch, getStore) => {

--- a/web/app/containers/product-details/actions.js
+++ b/web/app/containers/product-details/actions.js
@@ -1,4 +1,4 @@
-import {createAction, urlToPathKey} from '../../utils/utils'
+import {createAction, getCookieValue, urlToPathKey} from '../../utils/utils'
 import {makeFormEncodedRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
 import {browserHistory} from 'react-router'
 
@@ -11,6 +11,29 @@ import productDetailsParser from './parsers/product-details'
 
 import {isRunningInAstro} from '../../utils/astro-integration'
 import Astro from '../../vendor/astro-client'
+
+// From Magento page-cache.js
+const generateRandomString = (chars, length) => {
+    let result = ''
+    length = length > 0 ? length : 1
+
+    while (length--) {
+        result += chars[Math.round(Math.random() * (chars.length - 1))]
+    }
+
+    return result
+}
+
+const generateFormKeyCookie = () => {
+    // From Magento page-cache.js
+    const allowedCharacters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    const length = 16
+    const generatedKey = generateRandomString(allowedCharacters, length)
+    const lifetime = 3600
+    const expires = new Date((new Date().getTime()) + lifetime * 1000)
+    document.cookie = `form_key=${encodeURIComponent(generatedKey)}; expires=${expires.toGMTString()}; domain=.${window.location.hostname}`
+    return generatedKey
+}
 
 export const receiveNewItemQuantity = createAction('Set item quantity')
 export const setItemQuantity = (quantity) => (dispatch, getStore) => {
@@ -49,7 +72,8 @@ export const submitCartForm = () => (dispatch, getStore) => {
 
     return makeFormEncodedRequest(formInfo.get('submitUrl'), {
         ...formInfo.get('hiddenInputs').toJS(),
-        qty
+        qty,
+        form_key: getCookieValue('form_key') || generateFormKeyCookie()
     }, {
         method: formInfo.get('method')
     }).then(() => {

--- a/web/app/containers/product-details/actions.test.js
+++ b/web/app/containers/product-details/actions.test.js
@@ -23,6 +23,8 @@ afterAll(() => {
 })
 
 test('submitCartForm makes a request and dispatches updates', () => {
+    const formKeyValue = '12345'
+    document.cookie = `form_key=${formKeyValue}`
     const thunk = submitCartForm()
     expect(typeof thunk).toBe('function')
 
@@ -48,7 +50,8 @@ test('submitCartForm makes a request and dispatches updates', () => {
         .then(() => {
             expect(fetchUtils.makeFormEncodedRequest).toBeCalledWith(
                 'submitUrl',
-                {qty: 1},
+                {form_key: formKeyValue,
+                    qty: 1},
                 {method: 'POST'})
 
             expect(mockDispatch).toBeCalled()

--- a/web/app/store/cart/actions.js
+++ b/web/app/store/cart/actions.js
@@ -12,7 +12,7 @@ import {makeFormEncodedRequest, makeRequest} from 'progressive-web-sdk/dist/util
 import {addNotification, removeNotification} from '../../containers/app/actions'
 import {getFormKey} from '../../containers/app/selectors'
 
-const LOAD_CART_SECTION_URL = '/customer/section/load/?sections=cart%2Cmessages&update_section_id=true&_=<timestamp>'
+const LOAD_CART_SECTION_URL = '/customer/section/load/?sections=cart%2Cmessages&update_section_id=true'
 const REMOVE_CART_ITEM_URL = '/checkout/sidebar/removeItem/'
 const UPDATE_ITEM_URL = '/checkout/sidebar/updateItemQty/'
 const baseHeaders = {
@@ -29,7 +29,8 @@ export const getCart = () => (dispatch) => {
         headers: baseHeaders
     }
     dispatch(removeNotification('cartUpdateError'))
-    return makeRequest(`${LOAD_CART_SECTION_URL}${new Date().getTime()}`, opts)
+    const currentTimeMs = new Date().getTime()
+    return makeRequest(`${LOAD_CART_SECTION_URL}&_=${currentTimeMs}`, opts)
         .then((response) => response.text())
         .then((responseText) => dispatch(receiveCartContents(parse(responseText))))
 }

--- a/web/app/utils/magento-utils.js
+++ b/web/app/utils/magento-utils.js
@@ -33,9 +33,32 @@ export const getCheckoutConfigObject = ($html) => {
     return {}
 }
 
-
 export const getCheckoutEntityID = ($html) => {
     const configObject = getCheckoutConfigObject($html)
 
     return configObject && configObject.quoteData ? configObject.quoteData.entity_id : ''
+}
+
+// From Magento page-cache.js
+const generateRandomString = (chars, length) => {
+    let result = ''
+    length = length > 0 ? length : 1
+
+    while (length--) {
+        result += chars[Math.round(Math.random() * (chars.length - 1))]
+    }
+
+    return result
+}
+
+// Set the cookie and returns the value
+export const generateFormKeyCookie = () => {
+    // From Magento page-cache.js
+    const allowedCharacters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    const length = 16
+    const generatedKey = generateRandomString(allowedCharacters, length)
+    const lifetime = 3600
+    const expires = new Date((new Date().getTime()) + lifetime * 1000)
+    document.cookie = `form_key=${encodeURIComponent(generatedKey)}; expires=${expires.toGMTString()}; domain=.${window.location.hostname}`
+    return generatedKey
 }

--- a/web/app/utils/utils.js
+++ b/web/app/utils/utils.js
@@ -115,5 +115,11 @@ export const getPath = ({pathname, search}) => pathname + search
  * @returns {string} - the full URL for the given location
  */
 export const getURL = (location) =>
-      window.location.origin + getPath(location)
+    window.location.origin + getPath(location)
 
+
+// Regex courtesy of https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie
+export const getCookieValue = (cookieName) => {
+    const result = document.cookie.replace(new RegExp(`(?:(?:^|.*;\\s*)${cookieName}\\s*\\=\\s*([^;]*).*$)|^.*$`), '$1')
+    return result
+}


### PR DESCRIPTION
When the 'full page cache' is enabled on the Magento backend, add-to-cart flow changes a little. This PR fixes the PWA so it remains functional.

 **JIRA**: https://mobify.atlassian.net/browse/PLATT-95
 **Linked PRs**: #363, https://github.com/mobify/merlins-potions-magento/pull/19

## Changes
- Bugfix for checking cart contents request
- Include logic flow discovered from Magento JS for properly dealing with `form_key` when adding to cart

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Add to cart
- Try again with cookies cleared (or in incognito)
- Make sure it works in both cases
- Run your own Merlins instance locally, based on [this PR](https://github.com/mobify/merlins-potions-magento/pull/19)
- Build the image and run it
- Preview against `merlinspotions.local` (see [here for instructions](https://github.com/mobify/merlins-potions-magento/blob/master/README.md))
- Run the same Add to cart tests
- Observe they work
