### PR TITLE
Remove local react-router

### DIFF
--- a/web/app/containers/checkout-payment/actions.js
+++ b/web/app/containers/checkout-payment/actions.js
@@ -1,4 +1,4 @@
-import {browserHistory} from 'react-router'
+import {browserHistory} from 'progressive-web-sdk/dist/routing'
 import {createAction} from '../../utils/utils'
 import {makeRequest, makeJsonEncodedRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
 import {jqueryResponse} from 'progressive-web-sdk/dist/jquery-response'

--- a/web/app/containers/checkout-shipping/actions.js
+++ b/web/app/containers/checkout-shipping/actions.js
@@ -1,4 +1,4 @@
-import {browserHistory} from 'react-router'
+import {browserHistory} from 'progressive-web-sdk/dist/routing'
 import {createAction} from '../../utils/utils'
 import CheckoutShipping from './container'
 import checkoutShippingParser from './parsers/checkout-shipping'

--- a/web/app/containers/login/container.js
+++ b/web/app/containers/login/container.js
@@ -1,7 +1,7 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import {createStructuredSelector} from 'reselect'
-import {withRouter} from 'react-router'
+import {withRouter} from 'progressive-web-sdk/dist/routing'
 
 import SignInPanel from './partials/signin-panel'
 import RegisterPanel from './partials/register-panel'

--- a/web/app/containers/navigation/container.js
+++ b/web/app/containers/navigation/container.js
@@ -14,7 +14,7 @@ import {NAVIGATION_MODAL} from './constants'
 import {isModalOpen} from '../../store/selectors'
 import {closeModal} from '../../store/modals/actions'
 import {HeaderBar, HeaderBarActions, HeaderBarTitle} from 'progressive-web-sdk/dist/components/header-bar'
-import {withRouter} from 'react-router'
+import {withRouter} from 'progressive-web-sdk/dist/routing'
 
 
 /**

--- a/web/app/containers/product-details/actions.js
+++ b/web/app/containers/product-details/actions.js
@@ -1,6 +1,6 @@
 import {createAction, urlToPathKey} from '../../utils/utils'
 import {makeFormEncodedRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
-import {browserHistory} from 'react-router'
+import {browserHistory} from 'progressive-web-sdk/dist/routing'
 
 import {getCart} from '../../store/cart/actions'
 import * as selectors from './selectors'

--- a/web/app/router.jsx
+++ b/web/app/router.jsx
@@ -1,6 +1,5 @@
 import React, {PropTypes} from 'react'
-import {browserHistory} from 'react-router'
-import {Router as SDKRouter, Route, IndexRoute} from 'progressive-web-sdk/dist/routing'
+import {Router as SDKRouter, Route, IndexRoute, browserHistory} from 'progressive-web-sdk/dist/routing'
 import {Provider} from 'react-redux'
 
 // Containers

--- a/web/app/router.jsx
+++ b/web/app/router.jsx
@@ -1,5 +1,5 @@
 import React, {PropTypes} from 'react'
-import {Router as SDKRouter, Route, IndexRoute, browserHistory} from 'progressive-web-sdk/dist/routing'
+import {Router as SDKRouter, Route, IndexRoute} from 'progressive-web-sdk/dist/routing'
 import {Provider} from 'react-redux'
 
 // Containers
@@ -30,7 +30,7 @@ if (isRunningInAstro) {
 
 const Router = ({store}) => (
     <Provider store={store}>
-        <SDKRouter history={browserHistory}>
+        <SDKRouter>
             <Route path="/" component={App} onChange={OnChange}>
 
                 <IndexRoute component={Home} routeName="home" />

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,6 @@
     "react": "15.4.1",
     "react-dom": "15.4.1",
     "react-redux": "4.4.5",
-    "react-router": "2.7.0",
     "redux": "3.6.0",
     "redux-actions": "1.2.1",
     "redux-analytics": "0.3.1",


### PR DESCRIPTION
This PR removes all direct references to `react-router`, instead importing the re-exports from the SDK. This prevents version skew leading to duplication of the code in the final bundle. This decreases our vendor.js on Merlin's by 5kb gzipped, to 150kb. 

 **JIRA**: N/A

## Changes
- Remove react-router dependency
- Import `browserHistory` and `withRouter` from the SDK
- No longer pass our own `browserHistory` object since we're accessing the one in the SDK.

## How to test-drive this PR
- npm i
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- See that it still works (particularly the switching between tabs on the login page changing the URL and proceeding through the checkout)
