### PR TITLE
Home page demandware connector

### DIFF
--- a/web/app/containers/product-details/actions.test.js
+++ b/web/app/containers/product-details/actions.test.js
@@ -1,25 +1,16 @@
 /* eslint-env jest */
 import Immutable from 'immutable'
 
-import {addToCartStarted, addToCartComplete, submitCartForm} from './actions'
-import {PRODUCT_DETAILS_ITEM_ADDED_MODAL} from './constants'
-import {openModal} from '../../store/modals/actions'
+import {addToCartStarted, submitCartForm} from './actions'
 
-import * as fetchUtils from 'progressive-web-sdk/dist/utils/fetch-utils'
 
-jest.mock('../../store/cart/actions')
-import {getCart} from '../../store/cart/actions'
+import * as commands from '../../integration-manager/commands'
 
 /* eslint-disable import/namespace */
-let realMakeFormEncodedRequest
 beforeAll(() => {
-    realMakeFormEncodedRequest = fetchUtils.makeFormEncodedRequest
-    fetchUtils.makeFormEncodedRequest = jest.fn()
-    fetchUtils.makeFormEncodedRequest.mockReturnValue(Promise.resolve())
 })
 
 afterAll(() => {
-    fetchUtils.makeFormEncodedRequest = realMakeFormEncodedRequest
 })
 
 test('submitCartForm makes a request and dispatches updates', () => {
@@ -43,21 +34,13 @@ test('submitCartForm makes a request and dispatches updates', () => {
         }
     })
 
+    commands.addToCart = jest.fn()
     const mockDispatch = jest.fn()
-    return thunk(mockDispatch, getStore)
-        .then(() => {
-            expect(fetchUtils.makeFormEncodedRequest).toBeCalledWith(
-                'submitUrl',
-                {qty: 1},
-                {method: 'POST'})
+    thunk(mockDispatch, getStore)
 
-            expect(mockDispatch).toBeCalled()
-            expect(mockDispatch.mock.calls[0][0])
-                .toEqual(addToCartStarted())
-            expect(mockDispatch.mock.calls[1][0])
-                .toEqual(addToCartComplete())
-            expect(mockDispatch.mock.calls[2][0])
-                .toEqual(openModal(PRODUCT_DETAILS_ITEM_ADDED_MODAL))
-            expect(getCart).toBeCalled()
-        })
+    expect(mockDispatch).toBeCalled()
+    expect(mockDispatch.mock.calls[0][0])
+        .toEqual(addToCartStarted())
+    expect(mockDispatch.mock.calls[1][0])
+        .toEqual(commands.addToCart())
 })

--- a/web/app/integration-manager/demandware-connector/commands.js
+++ b/web/app/integration-manager/demandware-connector/commands.js
@@ -61,7 +61,7 @@ const getCurrentProductID = () => {
 const fetchNavigationData = () => (dispatch) => {
     const options = {
         method: 'GET',
-        headers: new Headers(REQUEST_HEADERS)
+        headers: requestHeaders
     }
     return makeRequest(`${API_END_POINT_URL}/categories/root?levels=2`, options)
         .then((response) => response.json())
@@ -96,7 +96,8 @@ export const fetchHomeData = () => (dispatch) => {
     return initDemandWareSession()
         .then(() => dispatch(fetchNavigationData()))
         .then(() => {
-            // TODO: How do we get banner info?
+            // Banners are being pulled from the bundle right now
+            // so we just need an array with the correct number of objects
             dispatch(receiveHomeData({banners: [{}, {}, {}]}))
         })
 }

--- a/web/app/integration-manager/merlins-connector/home/parser.test.js
+++ b/web/app/integration-manager/merlins-connector/home/parser.test.js
@@ -8,32 +8,6 @@ describe('the home parser', () => {
 
     it('should extract the home content from the rendered HTML', () => {
         const expected = {
-            categories: [
-                {
-                    href: 'https://www.merlinspotions.com/potions.html',
-                    text: 'Potions'
-                },
-                {
-                    href: 'https://www.merlinspotions.com/books.html',
-                    text: 'Books'
-                },
-                {
-                    href: 'https://www.merlinspotions.com/ingredients.html',
-                    text: 'Ingredients'
-                },
-                {
-                    href: 'https://www.merlinspotions.com/supplies.html',
-                    text: 'Supplies'
-                },
-                {
-                    href: 'https://www.merlinspotions.com/charms.html',
-                    text: 'Charms'
-                },
-                {
-                    href: 'https://www.merlinspotions.com/new-arrivals.html',
-                    text: 'New Arrivals'
-                }
-            ],
             // TODO: Update this expected object after we update desktop with new content
             banners: [
                 {
@@ -48,7 +22,6 @@ describe('the home parser', () => {
             ]
         }
 
-        expect(parsedContent.categories).toEqual(expected.categories)
         expect(parsedContent.banners).toEqual(expected.banners)
     })
 })

--- a/web/app/integration-manager/merlins-connector/navigation/parser.test.js
+++ b/web/app/integration-manager/merlins-connector/navigation/parser.test.js
@@ -2,26 +2,28 @@
 import {jquerifyHtmlFile} from 'progressive-web-sdk/dist/test-utils'
 import * as parser from './parser'
 
+const PARSER_PATH = 'app/integration-manager/merlins-connector/navigation'
+
 describe('the navigation parser', () => {
 
     const expectedRoot = {title: 'Root', path: '/', children: [
         {title: 'Sign In', path: 'http://www.merlinspotions.com/customer/account/login/', type: 'AccountNavItem'},
-        {title: 'Potions', path: 'http://www.merlinspotions.com/potions.html'},
-        {title: 'Books', path: 'http://www.merlinspotions.com/books.html'},
-        {title: 'Ingredients', path: 'http://www.merlinspotions.com/ingredients.html'},
-        {title: 'Supplies', path: 'http://www.merlinspotions.com/supplies.html'},
-        {title: 'Charms', path: 'http://www.merlinspotions.com/charms.html'},
-        {title: 'New Arrivals', path: 'http://www.merlinspotions.com/new-arrivals.html'}
+        {title: 'Potions', path: 'http://www.merlinspotions.com/potions.html', isCategoryLink: true},
+        {title: 'Books', path: 'http://www.merlinspotions.com/books.html', isCategoryLink: true},
+        {title: 'Ingredients', path: 'http://www.merlinspotions.com/ingredients.html', isCategoryLink: true},
+        {title: 'Supplies', path: 'http://www.merlinspotions.com/supplies.html', isCategoryLink: true},
+        {title: 'Charms', path: 'http://www.merlinspotions.com/charms.html', isCategoryLink: true},
+        {title: 'New Arrivals', path: 'http://www.merlinspotions.com/new-arrivals.html', isCategoryLink: true}
     ]}
 
     test('should extract navigation from the rendered HTML when no category is selected', () => {
-        const $content = jquerifyHtmlFile('app/containers/navigation/parsers/example.html')
+        const $content = jquerifyHtmlFile(`${PARSER_PATH}/example.html`)
         const expected = {root: expectedRoot, path: '/'}
         expect(parser.parseNavigation($, $content)).toEqual(expected)
     })
 
     test('should extract navigation from the rendered HTML when a category is selected', () => {
-        const $content = jquerifyHtmlFile('app/containers/navigation/parsers/example2.html')
+        const $content = jquerifyHtmlFile(`${PARSER_PATH}//example2.html`)
         const expected = {root: expectedRoot, path: 'http://www.merlinspotions.com/charms.html'}
         expect(parser.parseNavigation($, $content)).toEqual(expected)
     })

--- a/web/app/loader-routes.js
+++ b/web/app/loader-routes.js
@@ -1,4 +1,4 @@
 /* eslint-disable */
 // GENERATED FILE DO NOT EDIT
-const routes = [/^\/\/?$/,/^\/checkout\/cart\/?$/,/^\/customer\/account\/login\/?$/,/^\/customer\/account\/create\/?$/,/^\/potions\.html\/?$/,/^\/books\.html\/?$/,/^\/ingredients\.html\/?$/,/^\/supplies\.html\/?$/,/^\/new-arrivals\.html\/?$/,/^\/charms\.html\/?$/,/^\/checkout\/cart\/configure\/id\/.*?\/product_id\/.*?\/?$/,/^\/.*?\.html\/?$/,/^\/checkout\/?$/,/^\/checkout\/payment\/?$/,/^\/checkout\/onepage\/success\/?$/]
+const routes = [/^\/\/?$/,/^\/.*?\/Home-Show.*?\/?$/,/^\/checkout\/cart\/?$/,/^\/customer\/account\/login\/?$/,/^\/customer\/account\/create\/?$/,/^\/potions\.html\/?$/,/^\/books\.html\/?$/,/^\/ingredients\.html\/?$/,/^\/supplies\.html\/?$/,/^\/new-arrivals\.html\/?$/,/^\/charms\.html\/?$/,/^\/checkout\/cart\/configure\/id\/.*?\/product_id\/.*?\/?$/,/^\/.*?\.html\/?$/,/^\/checkout\/?$/,/^\/checkout\/payment\/?$/,/^\/checkout\/onepage\/success\/?$/]
 export default routes

--- a/web/app/main.jsx
+++ b/web/app/main.jsx
@@ -19,7 +19,7 @@ import Stylesheet from './stylesheet.scss' // eslint-disable-line no-unused-vars
 import {analyticManager} from 'progressive-web-sdk/dist/analytics/analytic-manager'
 import {clientAnalytics} from './utils/analytics/client-analytics'
 
-import connector from './integration-manager/merlins-connector'
+import connector from './integration-manager/demandware-connector'
 import {registerConnector} from './integration-manager'
 
 polyfill()

--- a/web/app/router.jsx
+++ b/web/app/router.jsx
@@ -35,6 +35,7 @@ const Router = ({store}) => (
             <Route path="/" component={App} onChange={OnChange}>
 
                 <IndexRoute component={Home} routeName="home" />
+                <Route component={Home} path="*/Home-Show*" routeName="home" />
                 <Route component={Cart} path="checkout/cart/" routeName="cart" />
                 <Route component={Login} path="customer/account/login/" routeName="signin" />
                 <Route component={Login} path="customer/account/create/" routeName="register" />


### PR DESCRIPTION
This PR adds fetching navigation data to the demand ware connector, and adds a route for the demandware homepage.

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1256
 **Linked PRs**: n/a

## Changes
- Added demandware home page to router
- Added command to fetch root level categories from the demandware API 

## How to test-drive this PR
- Set up tag injector for the demandware sandbox (http://mobify-tech-prtnr-na03-dw.demandware.net/on/demandware.store/Sites-2017refresh-Site/default/Home-Show)
- Run `npm run dev`
- Preview [the demandware site](https://preview.mobify.com/?url=http%3A%2F%2Fmobify-tech-prtnr-na03-dw.demandware.net%2Fon%2Fdemandware.store%2FSites-2017refresh-Site%2Fdefault%2FHome-Show&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- View the categories on the homepage and in the navigation
- They should match the categories available on the desktop site
